### PR TITLE
chore: failing NUT

### DIFF
--- a/test/commands/force/data/soql/query/dataSoqlQuery.nut.ts
+++ b/test/commands/force/data/soql/query/dataSoqlQuery.nut.ts
@@ -121,19 +121,20 @@ describe('data:soql:query command', () => {
     });
   });
 
-  describe('data:soql:query returns grandparents fields correctly', () => {
-    it('should return Lead.owner.name', () => {
+  describe('data:soql:query verify human results', () => {
+    it('should return Lead.owner.name (multi-level relationships)', () => {
       execCmd('force:data:record:create -s Lead -v "Company=Salesforce LastName=Astro"', { ensureExitCode: 0 });
       const query = 'SELECT owner.Profile.Name FROM lead LIMIT 1';
 
       const queryResult = runQuery(query, { ensureExitCode: 0 });
-
       expect(queryResult).to.not.include('[object Object]');
-      expect(queryResult).to.include('UUser');
-    });
-  });
+      expect(queryResult).to.include('System Administrator');
 
-  describe('data:soql:query verify human results', () => {
+      const queryResultCSV = runQuery(query + '" --resultformat "csv', { ensureExitCode: 0 });
+      expect(queryResultCSV).to.not.include('[object Object]');
+      expect(queryResultCSV).to.include('System Administrator');
+    });
+
     it('should return account records', () => {
       const query =
         "SELECT Id, Name, Phone, Website, NumberOfEmployees, Industry FROM Account WHERE Name LIKE 'SampleAccount%' limit 1";

--- a/test/commands/force/data/soql/query/dataSoqlQuery.nut.ts
+++ b/test/commands/force/data/soql/query/dataSoqlQuery.nut.ts
@@ -120,6 +120,19 @@ describe('data:soql:query command', () => {
       verifyRecordFields(contacts.records[0], ['LastName', 'Title', 'Email', 'attributes']);
     });
   });
+
+  describe('data:soql:query returns grandparents fields correctly', () => {
+    it('should return Lead.owner.name', () => {
+      execCmd('force:data:record:create -s Lead -v "Company=Salesforce LastName=Astro"', { ensureExitCode: 0 });
+      const query = 'SELECT owner.Profile.Name FROM lead LIMIT 1';
+
+      const queryResult = runQuery(query, { ensureExitCode: 0 });
+
+      expect(queryResult).to.not.include('[object Object]');
+      expect(queryResult).to.include('UUser');
+    });
+  });
+
   describe('data:soql:query verify human results', () => {
     it('should return account records', () => {
       const query =


### PR DESCRIPTION
### What does this PR do?
Adds a failing NUT to show the fix working
will fix the `[object Object]` in the following commits

### What issues does this PR fix or reference?
@W-9881177@
https://github.com/forcedotcom/cli/issues/1164