### PR TITLE
Update schema to support AJV

### DIFF
--- a/schema/dataImportPlanSchema.json
+++ b/schema/dataImportPlanSchema.json
@@ -1,6 +1,6 @@
 {
-  "_comment": "Copyright (c) 2016, salesforce.com, inc. All rights reserved. Licensed under the BSD 3-Clause license. For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$comment": "Copyright (c) 2016, salesforce.com, inc. All rights reserved. Licensed under the BSD 3-Clause license. For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "array",
   "title": "Data Import Plan",
   "description": "Schema for SFDX Toolbelt's data import plan JSON.",


### PR DESCRIPTION
### What does this PR do?
Updates the schema to support JSON Schema Draft 7 which is used in AJV. See https://github.com/forcedotcom/sfdx-core/pull/569

This can be merged at any point and does not need to wait for core changes.

These changes do not affect the current JSEN Draft 4 validation. 
(Additional reassurance: The schemas at https://github.com/forcedotcom/schemas are already declaring Draft 7 despite JSEN using Draft 4)

## Testing that Draft declaration does not matter
- Pull this branch
- Run unit and NU[T] tests (all pass)
- Pull https://github.com/forcedotcom/sfdx-core/pull/569
- `yarn link @salesforce/core`
- Run unit and NU[T] tests again (all pass)

### What issues does this PR fix or reference?
[@W-10818834@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-10818834)