### PR TITLE
fix: wait until all records are emitted

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+const oclif = require('@oclif/core');
+
+const path = require('path');
+const project = path.join(__dirname, '..', 'tsconfig.json');
+
+// In dev mode -> use ts-node and dev plugins
+process.env.NODE_ENV = 'development';
+
+require('ts-node').register({ project });
+
+// In dev mode, always show stack traces
+oclif.settings.debug = true;
+
+// Start the CLI
+oclif.run().then(oclif.flush).catch(oclif.Errors.handle);

--- a/bin/dev.cmd
+++ b/bin/dev.cmd
@@ -1,0 +1,3 @@
+@echo off
+
+node "%~dp0\dev" %*

--- a/package.json
+++ b/package.json
@@ -128,10 +128,10 @@
     "oclif": "^2.6.3",
     "prettier": "^2.4.1",
     "pretty-quick": "^3.1.0",
+    "shelljs": "^0.8.3",
     "shx": "^0.3.3",
     "sinon": "10.0.0",
     "ts-node": "^10.4.0",
-    "typescript": "^4.4.4",
-    "shelljs": "^0.8.3"
+    "typescript": "^4.4.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "@salesforce/plugin-command-reference": "^1.3.0",
     "@salesforce/prettier-config": "^0.0.2",
     "@salesforce/ts-sinon": "^1.3.15",
+    "@types/shelljs": "^0.8.10",
     "@types/chai-as-promised": "^7.1.3",
     "@types/graceful-fs": "^4.1.5",
     "@types/mkdirp": "^1.0.1",
@@ -130,6 +131,7 @@
     "shx": "^0.3.3",
     "sinon": "10.0.0",
     "ts-node": "^10.4.0",
-    "typescript": "^4.4.4"
+    "typescript": "^4.4.4",
+    "shelljs": "^0.8.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   "dependencies": {
     "@oclif/core": "^1.6.4",
     "@salesforce/command": "^5.1.3",
-    "@salesforce/core": "^3.19.0",
+    "@salesforce/core": "^3.21.1",
     "@salesforce/ts-types": "^1.5.20",
     "@types/fs-extra": "^9.0.13",
     "chalk": "^4.1.0",

--- a/src/commands/force/data/soql/query.ts
+++ b/src/commands/force/data/soql/query.ts
@@ -9,7 +9,7 @@ import * as os from 'os';
 import { flags, FlagsConfig } from '@salesforce/command';
 import { CliUx } from '@oclif/core';
 import { Connection, Logger, Messages, SfdxConfigAggregator } from '@salesforce/core';
-import { QueryOptions, Record } from 'jsforce';
+import { QueryOptions, QueryResult, Record } from 'jsforce';
 import {
   AnyJson,
   ensureJsonArray,
@@ -35,44 +35,53 @@ const commonMessages = Messages.loadMessages('@salesforce/plugin-data', 'message
  * Will collect all records and the column metadata of the query
  */
 export class SoqlQuery {
-  public async runSoqlQuery(connection: Connection, query: string, logger: Logger): Promise<SoqlQueryResult> {
-    const config: SfdxConfigAggregator = await SfdxConfigAggregator.create();
-
+  public async runSoqlQuery(
+    connection: Connection,
+    query: string,
+    logger: Logger,
+    configAgg: SfdxConfigAggregator
+  ): Promise<SoqlQueryResult> {
     let columns: Field[] = [];
     logger.debug('running query');
 
-    // take the limit from the config, then default 10,000
+    // take the limit from the config, then default 50,000
     const queryOpts: Partial<QueryOptions> = {
       autoFetch: true,
-      maxFetch: (config.getInfo('maxQueryLimit').value as number) || 10000,
+      maxFetch: (configAgg.getInfo('maxQueryLimit').value as number) || 50000,
     };
 
     const records: Record[] = [];
 
-    const result = await connection.query(query, queryOpts).on('record', (rec) => records.push(rec));
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises,no-async-promise-executor
+    const result: QueryResult<Record> = await new Promise(async (resolve, reject) => {
+      const res = await connection
+        .query(query, queryOpts)
+        .on('record', (rec) => records.push(rec))
+        .on('error', (err) => reject(err))
+        .on('end', () => {
+          resolve({
+            done: true,
+            totalSize: getNumber(res, 'totalSize', 0),
+            records,
+          });
+        });
+    });
 
-    const totalSize = getNumber(result, 'totalSize', 0);
-
-    if (records.length && totalSize > records.length) {
+    if (result.records.length && result.totalSize > result.records.length) {
       CliUx.ux.warn(
-        `The query result is missing ${totalSize - records.length} records due to a ${
+        `The query result is missing ${result.totalSize - result.records.length} records due to a ${
           queryOpts.maxFetch
-        } record limit. Increase the number of records returned by setting the config value "maxQueryLimit" or the environment variable "SFDX_MAX_QUERY_LIMIT" to ${totalSize} or greater than ${
-          queryOpts.maxFetch
-        }.`
+        } record limit. Increase the number of records returned by setting the config value "maxQueryLimit" or the environment variable "SFDX_MAX_QUERY_LIMIT" to ${
+          result.totalSize
+        } or greater than ${queryOpts.maxFetch}.`
       );
     }
 
-    logger.debug(`Query complete with ${totalSize} records returned`);
-    if (totalSize) {
+    logger.debug(`Query complete with ${result.totalSize} records returned`);
+    if (result.totalSize) {
       logger.debug('fetching columns for query');
       columns = await this.retrieveColumns(connection, query);
     }
-
-    result.records = records;
-    // remove nextRecordsUrl and force done to true
-    delete result.nextRecordsUrl;
-    result.done = true;
 
     return {
       query,
@@ -214,7 +223,12 @@ export class DataSoqlQueryCommand extends DataCommand {
       if (this.flags.resultformat !== 'json') this.ux.startSpinner(messages.getMessage('queryRunningMessage'));
       const query = new SoqlQuery();
       const conn = this.getConnection();
-      const queryResult: SoqlQueryResult = await query.runSoqlQuery(conn as Connection, this.flags.query, this.logger);
+      const queryResult: SoqlQueryResult = await query.runSoqlQuery(
+        conn as Connection,
+        this.flags.query,
+        this.logger,
+        this.configAggregator
+      );
       const results = {
         ...queryResult,
       };

--- a/src/commands/force/data/soql/query.ts
+++ b/src/commands/force/data/soql/query.ts
@@ -52,10 +52,9 @@ export class SoqlQuery {
 
     const records: Record[] = [];
 
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises,no-async-promise-executor
-    const result: QueryResult<Record> = await new Promise(async (resolve, reject) => {
-      const res = await connection
-        .query(query, queryOpts)
+    const result: QueryResult<Record> = await new Promise((resolve, reject) => {
+      const res = connection
+        .query(query)
         .on('record', (rec) => records.push(rec))
         .on('error', (err) => reject(err))
         .on('end', () => {
@@ -64,7 +63,8 @@ export class SoqlQuery {
             totalSize: getNumber(res, 'totalSize', 0),
             records,
           });
-        });
+        })
+        .run(queryOpts);
     });
 
     if (result.records.length && result.totalSize > result.records.length) {

--- a/test/commands/force/data/soql/query/dataSoqlQuery.nut.ts
+++ b/test/commands/force/data/soql/query/dataSoqlQuery.nut.ts
@@ -93,7 +93,7 @@ describe('data:soql:query command', () => {
 
     it('should return 3756 ScratchOrgInfo records', () => {
       //
-      // set maxQueryLimit to 2456 globally
+      // set maxQueryLimit to 3756 globally
       shell.exec('sfdx config:set maxQueryLimit=3756 -g', { silent: true });
 
       const soqlQuery = 'SELECT Id FROM ScratchOrgInfo';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1104,10 +1104,10 @@
     semver "^7.3.5"
     ts-retry-promise "^0.6.0"
 
-"@salesforce/core@^3.19.0":
-  version "3.19.1"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.19.1.tgz#bd154d2676a7ab320b4b3596e5bb61635c52a3fe"
-  integrity sha512-f2Up1N9dVFv4vEKxK97CrPu6IoYl56IynH6kv07/ZO/f4F6JTxpa27e88ZDmPiZw5eBzURhCWCYqpwk5ev0YBg==
+"@salesforce/core@^3.19.0", "@salesforce/core@^3.21.1":
+  version "3.21.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.21.1.tgz#3e51454d6e5f5fbf523e0372378210b8cf85f60f"
+  integrity sha512-TdOhTeXrfUhRsqqwQKQsA410uBvHsRQiD66wtC0lmUGHRBNxUYEmK6+zbMvVLyPLo6Db4GOPuZ/3DV839fIVBg==
   dependencies:
     "@salesforce/bunyan" "^2.0.0"
     "@salesforce/kit" "^1.5.41"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1351,7 +1351,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/glob@^7.1.1":
+"@types/glob@*", "@types/glob@^7.1.1":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
   integrity sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==
@@ -1439,6 +1439,14 @@
   version "7.3.9"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.9.tgz#152c6c20a7688c30b967ec1841d31ace569863fc"
   integrity sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==
+
+"@types/shelljs@^0.8.10":
+  version "0.8.11"
+  resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.8.11.tgz#17a5696c825974e96828e96e89585d685646fcb8"
+  integrity sha512-x9yaMvEh5BEaZKeVQC4vp3l+QoFj3BXcd4aYfuKSzIIyihjdVARAadYy3SMNIz0WCCdS2vB9JL/U6GQk5PaxQw==
+  dependencies:
+    "@types/glob" "*"
+    "@types/node" "*"
 
 "@types/sinon@*", "@types/sinon@10.0.11":
   version "10.0.11"
@@ -6995,7 +7003,7 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shelljs@^0.8.4, shelljs@^0.8.5, shelljs@~0.8.4:
+shelljs@^0.8.3, shelljs@^0.8.4, shelljs@^0.8.5, shelljs@~0.8.4:
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
   integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==


### PR DESCRIPTION
### What does this PR do?

Makes `SoqlQuery` wait until all records are emitted from jsforce, also it accepts a config aggregator as a parameter(no default, the caller should pass `this.configAggregator` or create a new instance.

others:
added 2 NUTs for maxQueryLimit
reverted default limit back to 50000

### What issues does this PR fix or reference?
@W-11204187@

https://github.com/forcedotcom/cli/issues/1543