### PR TITLE
fix: allow single quotes in key=value pairs

### DIFF
--- a/src/dataCommand.ts
+++ b/src/dataCommand.ts
@@ -222,26 +222,52 @@ export abstract class DataCommand extends SfdxCommand {
   }
 
   /**
-   * Splits a sequence of "key=value key=leftValue rightValue   key=value"
-   * into a list of key=value pairs, paying attention to whitespace in values.
-   *
-   * e.g. "key=value key=leftValue rightValue   key=value0"
-   * becomes ["key=value", "key=leftValue rightValue", "key=value"]
+   * Splits a sequence of 'key=value key="leftValue rightValue"   key=value'
+   * into a list of key=value pairs, paying attention to quoted whitespace.
    *
    * This is NOT a full push down-automaton so do NOT expect full error handling/recovery.
    *
    * @param {string} text - The sequence to split
    */
   private parseKeyValueSequence(text: string): string[] {
-    // The regex below uses a positive lookbehind and a positive lookahead to split the string into key=value pairs
-    //   regardless of whitespace or single quotes in the values
-    // Use regex101.com and paste this regex to see how it works
-    const matches = text.match(/(\S+)=(?<=['"]?)([\d\w'"\s]+)(?=\s|$)/g);
+    const separator = /\s/;
 
-    if (matches === null) {
-      throw new Error(messages.getMessage('TextUtilMalformedKeyValuePair', [text]));
+    let inSingleQuote = false;
+    let inDoubleQuote = false;
+    let currentToken: string[] = [];
+    const keyValuePairs: string[] = [];
+
+    const trimmedText = text.trim();
+
+    const singleQuoteCount = (trimmedText.match(/'/g) || []).length;
+    const doubleQuoteCount = (trimmedText.match(/"/g) || []).length;
+
+    for (const currentChar of trimmedText) {
+      const isSeparator = separator.exec(currentChar) !== null;
+
+      if (currentChar === "'" && !inDoubleQuote && singleQuoteCount >= 2) {
+        inSingleQuote = !inSingleQuote;
+        continue;
+      } else if (currentChar === '"' && !inSingleQuote && doubleQuoteCount >= 2) {
+        inDoubleQuote = !inDoubleQuote;
+        continue;
+      }
+
+      if (!inSingleQuote && !inDoubleQuote && isSeparator) {
+        if (currentToken.length > 0) {
+          keyValuePairs.push(currentToken.join(''));
+          currentToken = [];
+        }
+      } else {
+        currentToken.push(currentChar);
+      }
     }
 
-    return matches.map((match) => match.trim());
+    // For the case of only one key=value pair with no separator
+    if (currentToken.length > 0) {
+      keyValuePairs.push(currentToken.join(''));
+    }
+
+    return keyValuePairs;
   }
 }

--- a/src/dataCommand.ts
+++ b/src/dataCommand.ts
@@ -243,7 +243,7 @@ export abstract class DataCommand extends SfdxCommand {
     const doubleQuoteCount = (trimmedText.match(/"/g) || []).length;
 
     for (const currentChar of trimmedText) {
-      const isSeparator = separator.exec(currentChar) !== null;
+      const isSeparator = separator.test(currentChar);
 
       if (currentChar === "'" && !inDoubleQuote && singleQuoteCount >= 2) {
         inSingleQuote = !inSingleQuote;

--- a/test/commands/force/data/dataCommand.test.ts
+++ b/test/commands/force/data/dataCommand.test.ts
@@ -62,34 +62,46 @@ describe('dataCommand', () => {
   });
 
   it('should allow single quotes in key=value pairs', () => {
-    const dict = dataCommand.testStringToDictionary('key1="val\'ue"');
+    let dict = dataCommand.testStringToDictionary('key="val\'ue"');
 
     expect(dict).to.deep.equal({
-      key1: "val'ue",
+      key: "val'ue",
+    });
+
+    dict = dataCommand.testStringToDictionary("key=val'ue");
+
+    expect(dict).to.deep.equal({
+      key: "val'ue",
     });
   });
 
   it('should allow double quotes in key=value pairs', () => {
-    const dict = dataCommand.testStringToDictionary("key1='val\"ue'");
+    let dict = dataCommand.testStringToDictionary("key='val\"ue'");
 
     expect(dict).to.deep.equal({
-      key1: 'val"ue',
+      key: 'val"ue',
+    });
+
+    dict = dataCommand.testStringToDictionary('key=val"ue');
+
+    expect(dict).to.deep.equal({
+      key: 'val"ue',
     });
   });
 
   it('should allow non alphanumeric characters in key=value pairs', () => {
-    const dict = dataCommand.testStringToDictionary('key1=!@#$%^&*()-_=+[{]}\\|;:,<.>/?`~');
+    const dict = dataCommand.testStringToDictionary('key=!@#$%^&*()-_=+[{]}\\|;:,<.>/?`~');
 
     expect(dict).to.deep.equal({
-      key1: '!@#$%^&*()-_=+[{]}\\|;:,<.>/?`~',
+      key: '!@#$%^&*()-_=+[{]}\\|;:,<.>/?`~',
     });
   });
 
   it('should allow weird or foreign unicode characters in key=value pairs', () => {
-    const dict = dataCommand.testStringToDictionary('key1=♣♦♥♠&£ë╤è☺¼Φ╚↕↓㍿々');
+    const dict = dataCommand.testStringToDictionary('key=♣♦♥♠&£ë╤è☺¼Φ╚↕↓㍿々');
 
     expect(dict).to.deep.equal({
-      key1: '♣♦♥♠&£ë╤è☺¼Φ╚↕↓㍿々',
+      key: '♣♦♥♠&£ë╤è☺¼Φ╚↕↓㍿々',
     });
   });
 });

--- a/test/commands/force/data/record/get.test.ts
+++ b/test/commands/force/data/record/get.test.ts
@@ -95,6 +95,6 @@ describe('force:data:record:get', () => {
     .it('should throw an error if values provided to where flag are invalid', (ctx) => {
       const result = JSON.parse(ctx.stdout) as GetResult;
       expect(result.status).to.equal(1);
-      expect(result.name).to.equal('Malformed key=value pair for value: "Name"');
+      expect(result.name).to.equal('Malformed key=value pair for value: Name');
     });
 });

--- a/test/commands/force/data/record/get.test.ts
+++ b/test/commands/force/data/record/get.test.ts
@@ -95,6 +95,6 @@ describe('force:data:record:get', () => {
     .it('should throw an error if values provided to where flag are invalid', (ctx) => {
       const result = JSON.parse(ctx.stdout) as GetResult;
       expect(result.status).to.equal(1);
-      expect(result.name).to.equal('Malformed key=value pair for value: Name');
+      expect(result.name).to.equal('Malformed key=value pair for value: "Name"');
     });
 });


### PR DESCRIPTION
### What does this PR do?
Allows using `'` in the value  of name-value pairs for flags such as `force:data:record:create`'s `--values`.

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/1820
@W-12105706@
