### PR TITLE
create data:export:bulk command

### DIFF
--- a/messages/bulkv2.query.md
+++ b/messages/bulkv2.query.md
@@ -1,0 +1,64 @@
+# summary
+
+Export data using the Bulk API V2. Read more clicking on this [link](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/queries.htm).
+
+# description
+
+This command enables Users to export a large amount of data from Salesforce and save to disk as CSV or JSON files.
+
+# examples
+
+- Export data as JSON
+
+  <%= config.bin %> <%= command.id %> --query "SELECT Id, Name, Account.Name FROM Contact"
+
+- Export data using a SOQL query defined in a file called "query.txt"
+
+  <%= config.bin %> <%= command.id %> --file query.txt
+
+- Export data as CSV
+
+  <%= config.bin %> <%= command.id %> --query "SELECT Id, Name, Account.Name FROM Contact" --output-format csv
+
+- Export data asynchronously
+
+  <%= config.bin %> <%= command.id %> --query "SELECT Id FROM Contact" --wait 0
+
+# flags.queryToExecute
+
+SOQL query to execute.
+
+# flags.file
+
+File that contains the SOQL query.
+
+# flags.wait
+
+Time to wait for the command to finish, in minutes.
+
+# flags.targetOrg.summary
+
+Org alias or username to use for the target org.
+
+# flags.outputDirectory
+
+Output directory where the file is going to be created. This folder must exist already, otherwise an exception is raised. If omitted, it defaults to the root of the current working directory.
+
+# flags.fileName
+
+File name without the file extension.
+
+# flags.outputFormat
+
+File output format: csv or json. It defaults to json.
+
+# queryRunningMessage
+
+Querying Data
+
+# queryTimeout
+
+Query ID: %s
+Query is in progress.
+
+Run "data export bulk resume -i %s -o %s --output-directory %s --file-name %s" to continue the data exporting process.

--- a/messages/soql.query.md
+++ b/messages/soql.query.md
@@ -40,14 +40,6 @@ Use Tooling API so you can run queries on Tooling API objects.
 
 File that contains the SOQL query.
 
-# flags.bulk
-
-Use Bulk API 2.0 to run the query.
-
-# flags.async
-
-Use Bulk API 2.0, but don't wait for the job to complete.
-
 # flags.wait
 
 Time to wait for the command to finish, in minutes.
@@ -63,10 +55,3 @@ Total number of records retrieved: %s.
 # queryRunningMessage
 
 Querying Data
-
-# bulkQueryTimeout
-
-Query ID: %s
-Query is in progress.
-
-Run "data query resume -i %s -o %s" to get the latest status and results.

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "csv-stringify": "^6.3.0",
     "fs-extra": "^10.0.1",
     "jsforce": "2.0.0-beta.20",
+    "json-2-csv": "^4.0.0",
     "tslib": "^2"
   },
   "devDependencies": {

--- a/src/commands/data/export/bulk.ts
+++ b/src/commands/data/export/bulk.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { Connection, Logger, Messages, SfError } from '@salesforce/core';
+import { Duration } from '@salesforce/kit';
+import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { QueryJobV2 } from 'jsforce/lib/api/bulk';
+import { Schema } from 'jsforce';
+import { orgFlags } from '../../../flags';
+import { BulkSoqlQueryResult } from '../../../dataSoqlQueryTypes';
+import { createFile } from '../../../bulkUtils';
+import { BulkQueryRequestCache } from '../../../bulkDataRequestCache';
+import { QUERY_MAX_RECORDS_PER_PAGE } from '../../../constants';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/plugin-data', 'bulkv2.query');
+
+export class BulkExport extends SfCommand<unknown> {
+  public static readonly summary = messages.getMessage('summary');
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessages('examples');
+  public static readonly deprecateAliases = true;
+
+  public static readonly flags = {
+    ...orgFlags,
+    query: Flags.string({
+      char: 'q',
+      summary: messages.getMessage('flags.queryToExecute'),
+      exactlyOne: ['query', 'file'],
+    }),
+    file: Flags.file({
+      char: 'f',
+      exists: true,
+      summary: messages.getMessage('flags.file'),
+      exactlyOne: ['query', 'file'],
+      aliases: ['soqlqueryfile'],
+      deprecateAliases: true,
+    }),
+    'output-directory': Flags.string({
+      summary: messages.getMessage('flags.outputDirectory'),
+      default: '.',
+    }),
+    'file-name': Flags.string({
+      summary: messages.getMessage('flags.fileName'),
+      default: 'data',
+    }),
+    'output-format': Flags.string({
+      summary: messages.getMessage('flags.outputFormat'),
+      options: ['csv', 'json'],
+      default: 'json',
+    }),
+    wait: Flags.duration({
+      unit: 'minutes',
+      char: 'w',
+      summary: messages.getMessage('flags.wait'),
+    }),
+  };
+
+  private logger!: Logger;
+
+  public async run(): Promise<unknown> {
+    this.logger = await Logger.child('data:soql:query');
+    const flags = (await this.parse(BulkExport)).flags;
+    this.spinner.start('Preparing Query Job');
+    // soqlqueryfile will be present if flags.query isn't. Oclif exactlyOne isn't quite that clever
+    const query = flags.query ?? fs.readFileSync(flags.file as string, 'utf8');
+    const conn = flags['target-org'].getConnection(flags['api-version']);
+    const queryResult = await this.runBulkSoqlQuery(
+      conn,
+      query,
+      this.logger,
+      flags.wait ?? Duration.minutes(0),
+      flags['output-directory'],
+      flags['file-name'],
+      flags['output-format']
+    );
+
+    return queryResult.result;
+  }
+  /**
+   * Executes a SOQL query using the bulk 2.0 API
+   *
+   * @param connection
+   * @param query
+   * @param timeout
+   */
+  private async runBulkSoqlQuery(
+    connection: Connection,
+    query: string,
+    logger: Logger,
+    timeout: Duration,
+    outputDirectory: string,
+    fileName: string,
+    outputFormat: string
+  ): Promise<BulkSoqlQueryResult> {
+    const filePath = path.resolve(outputDirectory, `${fileName}.${outputFormat}`);
+    let queryJob: QueryJobV2<Schema> | undefined;
+    try {
+      logger.debug('Processing Query Job');
+
+      connection.bulk2.pollTimeout = timeout.milliseconds ?? Duration.minutes(5).milliseconds;
+      queryJob = await connection.bulk2.query(query, {
+        // TODO: enable users to change this value based on an env variable called SF_BULK_API_V2_QUERY_MAX_RECORDS
+        maxRecords: QUERY_MAX_RECORDS_PER_PAGE,
+      });
+
+      logger.debug(`Query Job ${queryJob.jobInfo?.id} processed with success`);
+      this.spinner.stop();
+      this.log(`Query Job ${queryJob.jobInfo?.id} processed with success`);
+      this.progress.start(queryJob.jobInfo?.numberRecordsProcessed as number);
+
+      const readStream = queryJob.stream();
+      readStream.on('data', () => {
+        logger.debug(`${queryJob?.jobInfo?.id} processed ${queryJob?.numberRecordsRetrieved as number} records`);
+        this.progress.update(queryJob?.numberRecordsRetrieved as number);
+      });
+
+      logger.debug('Writting data to disk');
+      await createFile(readStream, filePath);
+      logger.debug(`All records for Query Job ${queryJob.jobInfo?.id} were saved to disk`);
+
+      return {
+        query,
+        result: {
+          done: true,
+          totalSize: queryJob?.numberRecordsRetrieved,
+          filePath,
+        },
+      };
+    } catch (e) {
+      const err = e as Error & { jobId: string };
+      if (timeout.minutes === 0 && err.message.includes('Polling time out')) {
+        // async query, so we can't throw an error, suggest data:query:resume --queryid <id>
+        const cache = await BulkQueryRequestCache.create();
+        await cache.createCacheEntryForRequest(err.jobId, connection.getUsername(), connection.getApiVersion());
+        this.log(
+          messages.getMessage('queryTimeout', [
+            err.jobId,
+            err.jobId,
+            connection.getUsername(),
+            outputDirectory,
+            fileName,
+          ])
+        );
+        return {
+          query,
+          result: { done: false, totalSize: queryJob?.numberRecordsRetrieved as number, filePath, id: err.jobId },
+        };
+      } else {
+        throw SfError.wrap(err);
+      }
+    } finally {
+      this.progress.stop();
+    }
+  }
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+export const QUERY_MAX_RECORDS_PER_PAGE = 100000;

--- a/src/dataSoqlQueryTypes.ts
+++ b/src/dataSoqlQueryTypes.ts
@@ -29,11 +29,24 @@ export interface Field {
  */
 export type SoqlQueryResult = {
   query: string;
+  result: QueryResult<Record>;
+  columns: Field[];
+};
+
+/**
+ * Type to define Bulk SOQL Query results
+ */
+export type BulkSoqlQueryResult = {
+  query: string;
   // an id can be present when a bulk query times out
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore jsforce v2 types are too strict for running general queries
-  result: QueryResult<Record> & { id?: string };
-  columns: Field[];
+  result: {
+    done: boolean;
+    totalSize: number;
+    filePath: string;
+    id?: string;
+  };
 };
 
 export type BasicRecord = {

--- a/src/queryUtils.ts
+++ b/src/queryUtils.ts
@@ -4,8 +4,8 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { Record } from 'jsforce';
-import { Field, FieldType, SoqlQueryResult } from './dataSoqlQueryTypes';
+
+import { SoqlQueryResult } from './dataSoqlQueryTypes';
 import { CsvReporter, FormatTypes, HumanReporter, JsonReporter } from './reporters';
 
 export const displayResults = (queryResult: SoqlQueryResult, resultFormat: FormatTypes): void => {
@@ -24,27 +24,3 @@ export const displayResults = (queryResult: SoqlQueryResult, resultFormat: Forma
   // delegate to selected reporter
   reporter.display();
 };
-
-/**
- * transforms Bulk 2.0 results to match the SOQL query results
- *
- * @param results results object
- * @param query query string
- */
-export const transformBulkResults = (results: Record[], query: string): SoqlQueryResult => {
-  /*
-    bulk queries return a different payload, it's a [{column: data}, {column: data}]
-    so we just need to grab the first object, find the keys (columns) and create the columns
-     */
-  const columns: Field[] = Object.keys(results[0] ?? {}).map((name) => ({
-    fieldType: FieldType.field,
-    name,
-  }));
-
-  return {
-    columns,
-    result: { done: true, records: results, totalSize: results.length },
-    query,
-  };
-};
-


### PR DESCRIPTION
### What does this PR do?

- it adds the `data:export:bulk` command. This command is able to export all records of an sobject using the Bulk API V2 without throwing  `FATAL Error: Javascript Heap out of Memory`. 

- it removes bulk features from the `data:soql:query` command. I decided to do that because in my opinion it makes more sense to use the bulk api to export data only. If people want to display a LIMITED number of records, they can use normal apis.

# Demo

obs: pay attention to the amount of memory and CPU that is used on each execution. This information is displayed in the VS Code status bar

![image](https://user-images.githubusercontent.com/55927613/227749486-93aee165-502d-4520-b1dd-8f95f14dd979.png)


### exporting as json


https://user-images.githubusercontent.com/55927613/227749221-7e9dbebf-3631-40ad-b106-615bdc3b839c.mov


### exporting as csv

https://user-images.githubusercontent.com/55927613/227749198-6052bd4a-6e1b-485b-82e5-37a51209c4fa.mov


### sync json output
![image](https://user-images.githubusercontent.com/55927613/228091854-759abc68-3f70-41b7-ae34-4536104308b0.png)

### async json output
![image](https://user-images.githubusercontent.com/55927613/228091931-c8d5a976-5f40-4d45-8f88-cae9c3f72d03.png)



### What issues does this PR fix or reference?

https://github.com/forcedotcom/cli/issues/1995



