### PR TITLE
fix: exit 1 when any batch/record fails

### DIFF
--- a/src/BulkBaseCommand.ts
+++ b/src/BulkBaseCommand.ts
@@ -47,6 +47,7 @@ export abstract class BulkBaseCommand extends SfCommand<BulkResultV2> {
       this.info(getResultMessage(jobInfo));
       if ((jobInfo.numberRecordsFailed ?? 0) > 0 || jobInfo.state === 'Failed') {
         this.info(messages.getMessage('checkJobViaUi', [this.config.bin, this.connection?.getUsername(), jobInfo.id]));
+        process.exitCode = 1;
       }
       if (jobInfo.state === 'InProgress' || jobInfo.state === 'Open') {
         this.info(


### PR DESCRIPTION
### What does this PR do?
when any batch/record fails in the bulk api transaction, set the exitcode to 1

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/1648
@W-11509580@

QA:
create a project
create an org
Make a "bad" csv like this 
```csv
Id
0000sdfsdfsdf
```
`../bin/dev data:delete:bulk --sobject Account --file ../foo.csv --wait 50`
