### PR TITLE
fix: assert flag type

### DIFF
--- a/messages/messages.md
+++ b/messages/messages.md
@@ -39,10 +39,6 @@ Cannot create a cache entry without a valid org.
 
 A valid username is required when creating a cache entry.
 
-# flags.targetOrg.summary
-
-Org alias or username to use for the target org.
-
 # invalidSobject
 
 The supplied SObject type "%s" is invalid. Error message: %s.

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -4,7 +4,8 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { Messages } from '@salesforce/core';
+import { Interfaces } from '@oclif/core';
+import { Messages, Org } from '@salesforce/core';
 import {
   Flags,
   loglevel,
@@ -24,8 +25,17 @@ export const perflogFlag = Flags.boolean({
   },
 });
 
+// Modifying a custom flag is an anti-pattern. Creating a new
+// custom flag is the preferred approach. But if it must be done,
+// then the type must be asserted so that @oclif/core can properly
+// parse the flag's type.
+const targetOrg = {
+  ...requiredOrgFlagWithDeprecations,
+  summary: messages.getMessage('flags.targetOrg.summary'),
+} as Interfaces.OptionFlag<Org>;
+
 export const orgFlags = {
-  'target-org': { ...requiredOrgFlagWithDeprecations, summary: messages.getMessage('flags.targetOrg.summary') },
+  'target-org': targetOrg,
   'api-version': orgApiVersionFlagWithDeprecations,
   loglevel,
 };

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -4,8 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { Interfaces } from '@oclif/core';
-import { Messages, Org } from '@salesforce/core';
+import { Messages } from '@salesforce/core';
 import {
   Flags,
   loglevel,
@@ -25,17 +24,8 @@ export const perflogFlag = Flags.boolean({
   },
 });
 
-// Modifying a custom flag is an anti-pattern. Creating a new
-// custom flag is the preferred approach. But if it must be done,
-// then the type must be asserted so that @oclif/core can properly
-// parse the flag's type.
-const targetOrg = {
-  ...requiredOrgFlagWithDeprecations,
-  summary: messages.getMessage('flags.targetOrg.summary'),
-} as Interfaces.OptionFlag<Org>;
-
 export const orgFlags = {
-  'target-org': targetOrg,
+  'target-org': requiredOrgFlagWithDeprecations,
   'api-version': orgApiVersionFlagWithDeprecations,
   loglevel,
 };


### PR DESCRIPTION
### What does this PR do?

Assert `target-org` flag type so that `@oclif/core@v3` won't think that it's possibly undefined. 

Using the spread operator to extend flags is an anti-pattern and should be avoided. The types in v3 are more accurate which means we can no longer get away with anti-patterns like this. If we have to do this sort of thing the better approach would be to expose the defaults for the custom flag so that they can be reused.

So instead of this,

```typescript
// @salesforce/sf-plugins-core
export const requiredHubFlagWithDeprecations = requiredHubFlag({
  aliases: ['targetdevhubusername'],
  deprecateAliases: true,
  required: true,
});
```

```typescript
// @salesforce/plugin-data
'target-org': {...requiredHubFlagWithDeprecations, summary: 'a summary'}
```

You would do this,

```typescript
// @salesforce/sf-plugins-core
export const requiredHubFlagWithDeprecationsDefaults = {
  aliases: ['targetdevhubusername'],
  deprecateAliases: true,
  required: true,
};
```

```typescript
// @salesforce/plugin-data
'target-org': Flags.custom<Org>(requiredHubFlagWithDeprecationsDefaults)(
  { summary: 'a summary' },
)
```

### What issues does this PR fix or reference?
[skip-validate-pr]