### PR TITLE
fix: bulk update/upsert commands mention "delete"

### DIFF
--- a/messages/bulk.operation.command.md
+++ b/messages/bulk.operation.command.md
@@ -1,10 +1,10 @@
 # flags.sobject.summary
 
-API name of the Salesforce object, either standard or custom, that you want to delete records from.
+API name of the Salesforce object, either standard or custom, that you want to update or delete records from.
 
 # flags.csvfile.summary
 
-CSV file that contains the IDs of the records to delete.
+CSV file that contains the IDs of the records to update or delete.
 
 # flags.wait.summary
 

--- a/messages/record.update.md
+++ b/messages/record.update.md
@@ -4,7 +4,7 @@ Updates a single record of a Salesforce or Tooling API object.
 
 # description
 
-Specify the record you want to update with either its ID or with a list of field-value pairs that identify the record. If your list of fields identifies more than one record, the delete fails; the error displays how many records were found.
+Specify the record you want to update with either its ID or with a list of field-value pairs that identify the record. If your list of fields identifies more than one record, the update fails; the error displays how many records were found.
 
 When using field-value pairs for both identifying the record and specifiyng the new field values, use the format <fieldName>=<value>. Enclose all field-value pairs in one set of double quotation marks, delimited by spaces. Enclose values that contain spaces in single quotes.
 


### PR DESCRIPTION
### What does this PR do?

Some help for bulk update/upsert commands mention deleting, so I either changed the word, or in the case where the same flag summary was being used for two commands, I change "delete" to "update or delete". 

### What issues does this PR fix or reference?

@W-14250905@
