### PR TITLE
fix: static import schema help

### DIFF
--- a/messages/tree.import.md
+++ b/messages/tree.import.md
@@ -35,3 +35,14 @@ Display schema information for the --plan configuration file to stdout; if you s
 - Import records using a plan definition file into your default org:
 
   <%= config.bin %> <%= command.id %> --plan Account-Contact-plan.json
+
+# schema-help
+
+schema(array) - Data Import Plan: Schema for SFDX Toolbelt's data import plan JSON.
+
+- items(object) - SObject Type: Definition of records to be insert per SObject Type
+  - sobject(string) - Name of SObject: Child file references must have SObject roots of this type
+  - saveRefs(boolean) - Save References: Post-save, save references (Name/ID) to be used for reference replacement in subsequent saves. Applies to all data files for this SObject type.
+  - resolveRefs(boolean) - Resolve References: Pre-save, replace @<reference> with ID from previous save. Applies to all data files for this SObject type.
+  - files(array) - Files: An array of files paths to load
+  - items(string|object) - Filepath: Filepath string or object to point to a JSON or XML file having data defined in SObject Tree format.

--- a/schema/dataImportPlanSchema.json
+++ b/schema/dataImportPlanSchema.json
@@ -3,7 +3,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "array",
   "title": "Data Import Plan",
-  "description": "Schema for SFDX Toolbelt's data import plan JSON.",
+  "description": "Schema for data import plan JSON.",
   "items": {
     "type": "object",
     "title": "SObject Type",

--- a/src/commands/data/import/tree.ts
+++ b/src/commands/data/import/tree.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Logger, Messages, SchemaPrinter } from '@salesforce/core';
+import { Messages } from '@salesforce/core';
 import { getString, JsonMap } from '@salesforce/ts-types';
 import { SfCommand, Flags, arrayWithDeprecation } from '@salesforce/sf-plugins-core';
 import { ImportApi, ImportConfig } from '../../../api/data/tree/importApi';
@@ -61,7 +61,6 @@ export default class Import extends SfCommand<ImportResult[] | JsonMap> {
 
   public async run(): Promise<ImportResult[] | JsonMap> {
     const { flags } = await this.parse(Import);
-    const logger = await Logger.child('Import');
     const importApi = new ImportApi(
       flags['target-org'],
       this.config.bin,
@@ -71,9 +70,7 @@ export default class Import extends SfCommand<ImportResult[] | JsonMap> {
     if (flags['config-help']) {
       // Display config help and return
       const schema = importApi.getSchema();
-      if (!this.jsonEnabled()) {
-        new SchemaPrinter(logger, schema).getLines().forEach((line) => this.log(line));
-      }
+      this.log(messages.getMessage('schema-help'));
 
       return schema;
     }


### PR DESCRIPTION
### What does this PR do?

there is an entire set of classes in sfdx-core that's only used by plugin-data.

what do they do?  print what's now in `messages/tree.import` in an exquisitely complicated process based on the contents of `schema/dataImportPlanSchema.json`

also updated that to not talk about the Sfdx Toolbelt.  😄 

### What issues does this PR fix or reference?
tangentially related to [@W-14085765@](https://gus.lightning.force.com/a07EE00001a9pRDYAY) 

[removing deprecated stuff from sfdx-core because major release because configFile]