### PR TITLE
fix: support baseFlags on SfCommand

### DIFF
--- a/src/bulkOperationCommand.ts
+++ b/src/bulkOperationCommand.ts
@@ -8,7 +8,6 @@ import fs from 'node:fs';
 import { ReadStream } from 'node:fs';
 import os from 'node:os';
 
-
 import { Flags } from '@salesforce/sf-plugins-core';
 import { Duration } from '@salesforce/kit';
 import { Connection, Messages } from '@salesforce/core';
@@ -27,7 +26,7 @@ import { BulkResultV2 } from './types.js';
 import { isBulkV2RequestDone, transformResults, waitOrTimeout } from './bulkUtils.js';
 import { BulkBaseCommand } from './BulkBaseCommand.js';
 
-Messages.importMessagesDirectoryFromMetaUrl(import.meta.url)
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-data', 'bulk.operation.command');
 
 type CreateJobOptions = {
@@ -40,6 +39,7 @@ type CreateJobOptions = {
 export abstract class BulkOperationCommand extends BulkBaseCommand {
   public static readonly baseFlags = {
     ...orgFlags,
+    ...BulkBaseCommand.baseFlags,
     file: Flags.file({
       char: 'f',
       summary: messages.getMessage('flags.csvfile.summary'),

--- a/src/resumeBulkCommand.ts
+++ b/src/resumeBulkCommand.ts
@@ -5,7 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-
 import { Flags, loglevel, optionalOrgFlagWithDeprecations } from '@salesforce/sf-plugins-core';
 import { IngestJobV2, IngestOperation } from 'jsforce/lib/api/bulk.js';
 import { Messages } from '@salesforce/core';
@@ -15,11 +14,12 @@ import { BulkResultV2, ResumeOptions } from './types.js';
 import { isBulkV2RequestDone, transformResults, waitOrTimeout } from './bulkUtils.js';
 import { BulkBaseCommand } from './BulkBaseCommand.js';
 
-Messages.importMessagesDirectoryFromMetaUrl(import.meta.url)
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-data', 'bulk.resume.command');
 
 export abstract class ResumeBulkCommand extends BulkBaseCommand {
   public static readonly baseFlags = {
+    ...BulkBaseCommand.baseFlags,
     'target-org': { ...optionalOrgFlagWithDeprecations, summary: messages.getMessage('flags.targetOrg.summary') },
     'job-id': Flags.salesforceId({
       length: 18,


### PR DESCRIPTION
### What does this PR do?

Fix compilation errors when `SfCommand` has `baseFlags`. Can be merged independently of https://github.com/salesforcecli/sf-plugins-core/pull/519

### What issues does this PR fix or reference?
@W-15213828@