### PR TITLE
fix: spread SfCommand.baseFlags

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -4,7 +4,17 @@
     "command": "data:create:record",
     "flagAliases": ["apiversion", "sobjecttype", "targetusername", "u", "usetoolingapi"],
     "flagChars": ["o", "s", "t", "v"],
-    "flags": ["api-version", "json", "loglevel", "perflog", "sobject", "target-org", "use-tooling-api", "values"],
+    "flags": [
+      "api-version",
+      "flags-dir",
+      "json",
+      "loglevel",
+      "perflog",
+      "sobject",
+      "target-org",
+      "use-tooling-api",
+      "values"
+    ],
     "plugin": "@salesforce/plugin-data"
   },
   {
@@ -12,7 +22,18 @@
     "command": "data:delete:bulk",
     "flagAliases": ["apiversion", "csvfile", "sobjecttype", "targetusername", "u"],
     "flagChars": ["a", "f", "o", "s", "w"],
-    "flags": ["api-version", "async", "file", "json", "loglevel", "sobject", "target-org", "verbose", "wait"],
+    "flags": [
+      "api-version",
+      "async",
+      "file",
+      "flags-dir",
+      "json",
+      "loglevel",
+      "sobject",
+      "target-org",
+      "verbose",
+      "wait"
+    ],
     "plugin": "@salesforce/plugin-data"
   },
   {
@@ -22,6 +43,7 @@
     "flagChars": ["i", "o", "s", "t", "w"],
     "flags": [
       "api-version",
+      "flags-dir",
       "json",
       "loglevel",
       "perflog",
@@ -38,7 +60,7 @@
     "command": "data:delete:resume",
     "flagAliases": ["jobid", "targetusername", "u"],
     "flagChars": ["i", "o"],
-    "flags": ["api-version", "job-id", "json", "loglevel", "target-org", "use-most-recent", "wait"],
+    "flags": ["api-version", "flags-dir", "job-id", "json", "loglevel", "target-org", "use-most-recent", "wait"],
     "plugin": "@salesforce/plugin-data"
   },
   {
@@ -46,7 +68,7 @@
     "command": "data:export:beta:tree",
     "flagAliases": ["apiversion", "outputdir", "targetusername", "u"],
     "flagChars": ["d", "o", "p", "q", "x"],
-    "flags": ["api-version", "json", "loglevel", "output-dir", "plan", "prefix", "query", "target-org"],
+    "flags": ["api-version", "flags-dir", "json", "loglevel", "output-dir", "plan", "prefix", "query", "target-org"],
     "plugin": "@salesforce/plugin-data"
   },
   {
@@ -54,7 +76,7 @@
     "command": "data:export:tree",
     "flagAliases": ["apiversion", "outputdir", "targetusername", "u"],
     "flagChars": ["d", "o", "p", "q", "x"],
-    "flags": ["api-version", "json", "loglevel", "output-dir", "plan", "prefix", "query", "target-org"],
+    "flags": ["api-version", "flags-dir", "json", "loglevel", "output-dir", "plan", "prefix", "query", "target-org"],
     "plugin": "@salesforce/plugin-data"
   },
   {
@@ -64,6 +86,7 @@
     "flagChars": ["i", "o", "s", "t", "w"],
     "flags": [
       "api-version",
+      "flags-dir",
       "json",
       "loglevel",
       "perflog",
@@ -80,7 +103,7 @@
     "command": "data:import:beta:tree",
     "flagAliases": ["apiversion", "sobjecttreefiles", "targetusername", "u"],
     "flagChars": ["f", "o", "p"],
-    "flags": ["api-version", "files", "json", "loglevel", "plan", "target-org"],
+    "flags": ["api-version", "files", "flags-dir", "json", "loglevel", "plan", "target-org"],
     "plugin": "@salesforce/plugin-data"
   },
   {
@@ -88,7 +111,17 @@
     "command": "data:import:tree",
     "flagAliases": ["apiversion", "confighelp", "contenttype", "sobjecttreefiles", "targetusername", "u"],
     "flagChars": ["c", "f", "o", "p"],
-    "flags": ["api-version", "config-help", "content-type", "files", "json", "loglevel", "plan", "target-org"],
+    "flags": [
+      "api-version",
+      "config-help",
+      "content-type",
+      "files",
+      "flags-dir",
+      "json",
+      "loglevel",
+      "plan",
+      "target-org"
+    ],
     "plugin": "@salesforce/plugin-data"
   },
   {
@@ -102,6 +135,7 @@
       "async",
       "bulk",
       "file",
+      "flags-dir",
       "json",
       "loglevel",
       "perflog",
@@ -118,7 +152,16 @@
     "command": "data:query:resume",
     "flagAliases": ["apiversion", "bulkqueryid", "resultformat", "targetusername", "u"],
     "flagChars": ["i", "o", "r"],
-    "flags": ["api-version", "bulk-query-id", "json", "loglevel", "result-format", "target-org", "use-most-recent"],
+    "flags": [
+      "api-version",
+      "bulk-query-id",
+      "flags-dir",
+      "json",
+      "loglevel",
+      "result-format",
+      "target-org",
+      "use-most-recent"
+    ],
     "plugin": "@salesforce/plugin-data"
   },
   {
@@ -126,7 +169,7 @@
     "command": "data:resume",
     "flagAliases": ["apiversion", "batchid", "jobid", "targetusername", "u"],
     "flagChars": ["b", "i", "o"],
-    "flags": ["api-version", "batch-id", "job-id", "json", "loglevel", "target-org"],
+    "flags": ["api-version", "batch-id", "flags-dir", "job-id", "json", "loglevel", "target-org"],
     "plugin": "@salesforce/plugin-data"
   },
   {
@@ -136,6 +179,7 @@
     "flagChars": ["i", "o", "s", "t", "v", "w"],
     "flags": [
       "api-version",
+      "flags-dir",
       "json",
       "loglevel",
       "perflog",
@@ -158,6 +202,7 @@
       "async",
       "external-id",
       "file",
+      "flags-dir",
       "json",
       "loglevel",
       "sobject",
@@ -172,7 +217,7 @@
     "command": "data:upsert:resume",
     "flagAliases": ["jobid", "targetusername", "u"],
     "flagChars": ["i", "o"],
-    "flags": ["api-version", "job-id", "json", "loglevel", "target-org", "use-most-recent", "wait"],
+    "flags": ["api-version", "flags-dir", "job-id", "json", "loglevel", "target-org", "use-most-recent", "wait"],
     "plugin": "@salesforce/plugin-data"
   },
   {
@@ -180,7 +225,7 @@
     "command": "force:data:bulk:delete",
     "flagAliases": ["apiversion", "csvfile", "sobjecttype", "targetusername", "u"],
     "flagChars": ["f", "o", "s", "w"],
-    "flags": ["api-version", "file", "json", "loglevel", "sobject", "target-org", "wait"],
+    "flags": ["api-version", "file", "flags-dir", "json", "loglevel", "sobject", "target-org", "wait"],
     "plugin": "@salesforce/plugin-data"
   },
   {
@@ -188,7 +233,7 @@
     "command": "force:data:bulk:status",
     "flagAliases": ["apiversion", "batchid", "jobid", "targetusername", "u"],
     "flagChars": ["b", "i", "o"],
-    "flags": ["api-version", "batch-id", "job-id", "json", "loglevel", "target-org"],
+    "flags": ["api-version", "batch-id", "flags-dir", "job-id", "json", "loglevel", "target-org"],
     "plugin": "@salesforce/plugin-data"
   },
   {
@@ -196,7 +241,18 @@
     "command": "force:data:bulk:upsert",
     "flagAliases": ["apiversion", "csvfile", "externalid", "sobjecttype", "targetusername", "u"],
     "flagChars": ["f", "i", "o", "r", "s", "w"],
-    "flags": ["api-version", "external-id", "file", "json", "loglevel", "serial", "sobject", "target-org", "wait"],
+    "flags": [
+      "api-version",
+      "external-id",
+      "file",
+      "flags-dir",
+      "json",
+      "loglevel",
+      "serial",
+      "sobject",
+      "target-org",
+      "wait"
+    ],
     "plugin": "@salesforce/plugin-data"
   }
 ]

--- a/package.json
+++ b/package.json
@@ -109,10 +109,10 @@
   },
   "dependencies": {
     "@jsforce/jsforce-node": "^3.0.0-next.2",
-    "@oclif/core": "^3.23.0",
+    "@oclif/core": "^3.26.0",
     "@salesforce/core": "^6.7.1",
     "@salesforce/kit": "^3.0.15",
-    "@salesforce/sf-plugins-core": "^7.1.15",
+    "@salesforce/sf-plugins-core": "^8.0.0",
     "@salesforce/ts-types": "^2.0.9",
     "chalk": "^5.3.0",
     "change-case": "^5.4.3",

--- a/src/resumeBulkCommand.ts
+++ b/src/resumeBulkCommand.ts
@@ -17,6 +17,7 @@ const messages = Messages.loadMessages('@salesforce/plugin-data', 'bulk.resume.c
 
 export abstract class ResumeBulkCommand extends SfCommand<BulkResultV2> {
   public static readonly baseFlags = {
+    ...SfCommand.baseFlags,
     'target-org': optionalOrgFlagWithDeprecations,
     'job-id': Flags.salesforceId({
       length: 18,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1839,10 +1839,10 @@
     wordwrap "^1.0.0"
     wrap-ansi "^7.0.0"
 
-"@oclif/core@^3.15.1", "@oclif/core@^3.19.2", "@oclif/core@^3.20.0", "@oclif/core@^3.21.0", "@oclif/core@^3.23.0":
-  version "3.25.2"
-  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-3.25.2.tgz#a26d56abe5686c57c1e973957777bd2ae324e973"
-  integrity sha512-OkW/cNa/3DhoCz2YlSpymVe8DXqkoRaLY4SPTVqNVzR4R1dFBE5KoCtuwKwnhxYLCRCqaViPgRnB5K26f0MnjA==
+"@oclif/core@^3.15.1", "@oclif/core@^3.19.2", "@oclif/core@^3.20.0", "@oclif/core@^3.21.0", "@oclif/core@^3.23.0", "@oclif/core@^3.26.0":
+  version "3.26.0"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-3.26.0.tgz#959d5e9f13f4ad6a4e98235ad125189df9ee4279"
+  integrity sha512-TpMdfD4tfA2tVVbd4l0PrP02o5KoUXYmudBbTC7CeguDo/GLoprw4uL8cMsaVA26+cbcy7WYtOEydQiHVtJixA==
   dependencies:
     "@types/cli-progress" "^3.11.5"
     ansi-escapes "^4.3.2"
@@ -2143,10 +2143,10 @@
     chalk "^4"
     inquirer "^8.2.5"
 
-"@salesforce/sf-plugins-core@^7.1.15":
-  version "7.1.15"
-  resolved "https://registry.yarnpkg.com/@salesforce/sf-plugins-core/-/sf-plugins-core-7.1.15.tgz#4d6033d56d78cf6046abfce96c119a8a60ee7c07"
-  integrity sha512-dQSSIHEpeFIadkWqZE24068m01vy31hVJdGWYvgscTnNrR30jIC5fXRevYvGG0l+8vVEJkCYYnJFQabUjSw3Eg==
+"@salesforce/sf-plugins-core@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/sf-plugins-core/-/sf-plugins-core-8.0.0.tgz#00bea58d60075f6bf22679bad01a0debe5768dd9"
+  integrity sha512-S1ZAIn2aIi0qR7NBGVTmL8V1I62lDTEGWRlljNrdxx8qEFnz0Gt6LTdz0330FtVUIvJNPzvsAPOyjWjvlxDeow==
   dependencies:
     "@inquirer/confirm" "^2.0.17"
     "@inquirer/password" "^1.1.16"


### PR DESCRIPTION
### What does this PR do?

Fix compilation errors when `SfCommand` has `baseFlags`. Can be merged independently of https://github.com/salesforcecli/sf-plugins-core/pull/519

### What issues does this PR fix or reference?
@W-15213828@