### PR TITLE
feat: file upload

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -1,5 +1,13 @@
 [
   {
+    "alias": [],
+    "command": "data:create:file",
+    "flagAliases": [],
+    "flagChars": ["f", "i", "n", "o"],
+    "flags": ["api-version", "file", "flags-dir", "json", "name", "parent-id", "target-org"],
+    "plugin": "@salesforce/plugin-data"
+  },
+  {
     "alias": ["force:data:record:create"],
     "command": "data:create:record",
     "flagAliases": ["apiversion", "sobjecttype", "targetusername", "u", "usetoolingapi"],

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -3,8 +3,8 @@
     "alias": [],
     "command": "data:create:file",
     "flagAliases": [],
-    "flagChars": ["f", "i", "n", "o"],
-    "flags": ["api-version", "file", "flags-dir", "json", "name", "parent-id", "target-org"],
+    "flagChars": ["f", "i", "o", "t"],
+    "flags": ["api-version", "file", "flags-dir", "json", "parent-id", "target-org", "title"],
     "plugin": "@salesforce/plugin-data"
   },
   {

--- a/messages/data.create.file.md
+++ b/messages/data.create.file.md
@@ -10,9 +10,9 @@ By default, the uploaded file isn't attached to a record; in the Salesforce UI t
 
 You can also give the file a new name after it's been uploaded; by default its name in the org is the same as the local file name.
 
-# flags.name.summary
+# flags.title.summary
 
-New name given to the file after it's uploaded.
+New title given to the file (ContentDocument) after it's uploaded.
 
 # examples
 

--- a/messages/data.create.file.md
+++ b/messages/data.create.file.md
@@ -1,25 +1,32 @@
 # summary
 
-Upload a local file to an org
+Upload a local file to an org.
 
 # description
 
-Optionally, attach the file to an existing record and give it a new name.
+This command always creates a new file in the org; you can't update an existing file. After a successful upload, the command displays the ID of the new ContentDocument record which represents the uploaded file.
+
+By default, the uploaded file isn't attached to a record; in the Salesforce UI the file shows up in the Files tab. You can optionally attach the file to an existing record, such as an account, as long as you know its record ID.
+
+You can also give the file a new name after it's been uploaded; by default its name in the org is the same as the local file name.
 
 # flags.name.summary
 
-Name given to the created file.
+New name given to the file after it's uploaded.
 
 # examples
 
-- upload a local file to the default org
-  <%= config.bin %> <%= command.id %> --file path/to/astro.png
+- Upload the local file "resources/astro.png" to your default org:
 
-- give the file a different filename in the org  
-  <%= config.bin %> <%= command.id %> --file path/to/astro.png --name AstroOnABoat.png
+  <%= config.bin %> <%= command.id %> --file resources/astro.png
 
-- attach the file to a record in the org
-  <%= config.bin %> <%= command.id %> --file path/to/astro.png --parentid a03O900000LoJWPIA3
+- Give the file a different filename after it's uploaded to the org with alias "my-scratch":
+
+  <%= config.bin %> <%= command.id %> --file resources/astro.png --name AstroOnABoat.png --target-org my-scratch
+
+- Attach the file to a record in the org:
+
+  <%= config.bin %> <%= command.id %> --file path/to/astro.png --parent-id a03fakeLoJWPIA3
 
 # flags.file.summary
 
@@ -27,7 +34,7 @@ Path of file to upload.
 
 # flags.parent-id.summary
 
-Id of the record to attach the file to.
+ID of the record to attach the file to.
 
 # createSuccess
 
@@ -39,7 +46,7 @@ File attached to record with ID %s.
 
 # attachFailure
 
-The file was uploaded but not able to attach to the record.
+The file was successfully uploaded, but we weren't able to attach it to the record.
 
 # insufficientAccessActions
 

--- a/messages/data.create.file.md
+++ b/messages/data.create.file.md
@@ -22,7 +22,7 @@ New title given to the file (ContentDocument) after it's uploaded.
 
 - Give the file a different filename after it's uploaded to the org with alias "my-scratch":
 
-  <%= config.bin %> <%= command.id %> --file resources/astro.png --name AstroOnABoat.png --target-org my-scratch
+  <%= config.bin %> <%= command.id %> --file resources/astro.png --title AstroOnABoat.png --target-org my-scratch
 
 - Attach the file to a record in the org:
 

--- a/messages/data.create.file.md
+++ b/messages/data.create.file.md
@@ -1,0 +1,46 @@
+# summary
+
+Upload a local file to an org
+
+# description
+
+Optionally, attach the file to an existing record and give it a new name.
+
+# flags.name.summary
+
+Name given to the created file.
+
+# examples
+
+- upload a local file to the default org
+  <%= config.bin %> <%= command.id %> --file path/to/astro.png
+
+- give the file a different filename in the org  
+  <%= config.bin %> <%= command.id %> --file path/to/astro.png --name AstroOnABoat.png
+
+- attach the file to a record in the org
+  <%= config.bin %> <%= command.id %> --file path/to/astro.png --parentid a03O900000LoJWPIA3
+
+# flags.file.summary
+
+Path of file to upload.
+
+# flags.parent-id.summary
+
+Id of the record to attach the file to.
+
+# createSuccess
+
+Created file with ContentDocumentId %s.
+
+# attachSuccess
+
+File attached to record with ID %s.
+
+# attachFailure
+
+The file was uploaded but not able to attach to the record.
+
+# insufficientAccessActions
+
+- Check that the record ID is correct and that you have access to it.

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "longDescription": "Use the data commands to manipulate records in your org. Commands are available to help you work with various APIs. Import CSV files with the Bulk API V2. Export and import data with the SObject Tree Save API. Perform simple CRUD operations on individual records with the REST API.",
         "subtopics": {
           "create": {
-            "description": "Create a record."
+            "description": "Create a record or a file"
           },
           "delete": {
             "description": "Delete a single record or multiple records in bulk."
@@ -70,7 +70,8 @@
           "upsert": {
             "description": "Upsert many records."
           }
-        }
+        },
+        "external": true
       }
     },
     "flexibleTaxonomy": true,
@@ -115,13 +116,15 @@
     "chalk": "^5.3.0",
     "change-case": "^5.4.4",
     "csv-parse": "^4.16.3",
-    "csv-stringify": "^6.4.6"
+    "csv-stringify": "^6.4.6",
+    "form-data": "^4.0.0"
   },
   "devDependencies": {
     "@oclif/plugin-command-snapshot": "^5.1.9",
     "@salesforce/cli-plugins-testkit": "^5.3.4",
     "@salesforce/dev-scripts": "^9.1.1",
     "@salesforce/plugin-command-reference": "^3.0.83",
+    "@salesforce/types": "^1.1.0",
     "eslint-plugin-sf-plugin": "^1.18.3",
     "oclif": "^4.10.2",
     "ts-node": "^10.9.2",

--- a/src/api/data/tree/exportApi.ts
+++ b/src/api/data/tree/exportApi.ts
@@ -31,12 +31,12 @@ export type ExportConfig = {
   outputDir?: string;
   plan?: boolean;
   prefix?: string;
-}
+};
 
 type ParentRef = {
   id: string;
   fieldName: string;
-}
+};
 
 /**
  * Exports data from an org into sObject tree format.

--- a/src/api/data/tree/importApi.ts
+++ b/src/api/data/tree/importApi.ts
@@ -44,19 +44,19 @@ type DataImportComponents = {
   refMap: Map<string, string>;
   filepath: string;
   contentType?: string;
-}
+};
 
 export type ImportConfig = {
   contentType?: string;
   sobjectTreeFiles?: string[];
   plan?: string;
-}
+};
 
 type RequestMeta = {
   refRegex: RegExp;
   isJson: boolean;
   headers: Dictionary;
-}
+};
 
 /**
  * Imports data into an org that was exported to files using the export API.

--- a/src/api/data/tree/importTypes.ts
+++ b/src/api/data/tree/importTypes.ts
@@ -38,12 +38,12 @@ type TreeResponseError = {
 export type ResponseRefs = {
   referenceId: string;
   id: string;
-}
+};
 export type ImportResults = {
   responseRefs?: ResponseRefs[];
   sobjectTypes?: Dictionary;
   errors?: string[];
-}
+};
 
 export type ImportResult = {
   refId: string;

--- a/src/api/file/fileToContentVersion.ts
+++ b/src/api/file/fileToContentVersion.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { readFile } from 'node:fs/promises';
+import { basename } from 'node:path';
+import { Connection } from '@salesforce/core';
+import { Record, SaveResult } from '@jsforce/jsforce-node';
+import FormData from 'form-data';
+
+export type ContentVersion = {
+  Title: string;
+  FileExtension: string;
+  VersionData: string;
+  /** this could be undefined outside of our narrow use case (created files) */
+  ContentDocumentId: string;
+} & Record;
+
+type ContentVersionCreateRequest = {
+  PathOnClient: string;
+  Title?: string;
+};
+
+export async function file2CV(conn: Connection, filepath: string, name?: string): Promise<ContentVersion> {
+  const cvcr: ContentVersionCreateRequest = {
+    PathOnClient: filepath,
+    Title: name,
+  };
+
+  const form = new FormData();
+  form.append('VersionData', await readFile(filepath), { filename: name ?? basename(filepath) });
+  form.append('entity_content', JSON.stringify(cvcr), { contentType: 'application/json' });
+
+  // POST the multipart form to Salesforce's API, can't use the normal "create" action because it doesn't support multipart
+  const CV = await conn.request<SaveResult>({
+    url: '/sobjects/ContentVersion',
+    headers: { ...form.getHeaders() },
+    body: form.getBuffer(),
+    method: 'POST',
+  });
+
+  const result = await conn.query<ContentVersion>(
+    `Select Id, ContentDocumentId from ContentVersion where Id='${CV.id}'`
+  );
+  return result.records[0];
+}

--- a/src/api/file/fileToContentVersion.ts
+++ b/src/api/file/fileToContentVersion.ts
@@ -43,7 +43,7 @@ export async function file2CV(conn: Connection, filepath: string, name?: string)
   });
 
   const result = await conn.query<ContentVersion>(
-    `Select Id, ContentDocumentId from ContentVersion where Id='${CV.id}'`
+    `Select Id, ContentDocumentId, Title, FileExtension from ContentVersion where Id='${CV.id}'`
   );
   return result.records[0];
 }

--- a/src/api/file/fileToContentVersion.ts
+++ b/src/api/file/fileToContentVersion.ts
@@ -25,14 +25,14 @@ type ContentVersionCreateRequest = {
 };
 
 export async function file2CV(conn: Connection, filepath: string, title?: string): Promise<ContentVersion> {
-  const cvcr: ContentVersionCreateRequest = {
+  const req: ContentVersionCreateRequest = {
     PathOnClient: filepath,
     Title: title,
   };
 
   const form = new FormData();
   form.append('VersionData', await readFile(filepath), { filename: title ?? basename(filepath) });
-  form.append('entity_content', JSON.stringify(cvcr), { contentType: 'application/json' });
+  form.append('entity_content', JSON.stringify(req), { contentType: 'application/json' });
 
   // POST the multipart form to Salesforce's API, can't use the normal "create" action because it doesn't support multipart
   const CV = await conn.request<SaveResult>({
@@ -42,8 +42,7 @@ export async function file2CV(conn: Connection, filepath: string, title?: string
     method: 'POST',
   });
 
-  const result = await conn.query<ContentVersion>(
+  return conn.singleRecordQuery<ContentVersion>(
     `Select Id, ContentDocumentId, Title, FileExtension from ContentVersion where Id='${CV.id}'`
   );
-  return result.records[0];
 }

--- a/src/api/file/fileToContentVersion.ts
+++ b/src/api/file/fileToContentVersion.ts
@@ -24,14 +24,14 @@ type ContentVersionCreateRequest = {
   Title?: string;
 };
 
-export async function file2CV(conn: Connection, filepath: string, name?: string): Promise<ContentVersion> {
+export async function file2CV(conn: Connection, filepath: string, title?: string): Promise<ContentVersion> {
   const cvcr: ContentVersionCreateRequest = {
     PathOnClient: filepath,
-    Title: name,
+    Title: title,
   };
 
   const form = new FormData();
-  form.append('VersionData', await readFile(filepath), { filename: name ?? basename(filepath) });
+  form.append('VersionData', await readFile(filepath), { filename: title ?? basename(filepath) });
   form.append('entity_content', JSON.stringify(cvcr), { contentType: 'application/json' });
 
   // POST the multipart form to Salesforce's API, can't use the normal "create" action because it doesn't support multipart

--- a/src/commands/data/create/file.ts
+++ b/src/commands/data/create/file.ts
@@ -26,9 +26,9 @@ export default class DataCreateFile extends SfCommand<ContentVersion> {
   public static readonly flags = {
     'target-org': Flags.requiredOrg(),
     'api-version': Flags.orgApiVersion(),
-    name: Flags.string({
-      summary: messages.getMessage('flags.name.summary'),
-      char: 'n',
+    title: Flags.string({
+      summary: messages.getMessage('flags.title.summary'),
+      char: 't',
       required: false,
     }),
     file: Flags.file({
@@ -49,7 +49,7 @@ export default class DataCreateFile extends SfCommand<ContentVersion> {
   public async run(): Promise<ContentVersion> {
     const { flags } = await this.parse(DataCreateFile);
     const conn = flags['target-org'].getConnection(flags['api-version']);
-    const cv = await file2CV(conn, flags.file, flags.name);
+    const cv = await file2CV(conn, flags.file, flags.title);
     this.logSuccess(messages.getMessage('createSuccess', [cv.ContentDocumentId]));
 
     if (!flags['parent-id']) {

--- a/src/commands/data/create/file.ts
+++ b/src/commands/data/create/file.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { Messages, SfError } from '@salesforce/core';
+import { ContentVersion, file2CV } from '../../../api/file/fileToContentVersion.js';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+const messages = Messages.loadMessages('@salesforce/plugin-data', 'data.create.file');
+
+type CDLCreateRequest = {
+  ContentDocumentId: string;
+  LinkedEntityId: string;
+  ShareType: string;
+};
+
+export default class DataCreateFile extends SfCommand<ContentVersion> {
+  public static readonly summary = messages.getMessage('summary');
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessages('examples');
+
+  public static readonly flags = {
+    'target-org': Flags.requiredOrg(),
+    'api-version': Flags.orgApiVersion(),
+    name: Flags.string({
+      summary: messages.getMessage('flags.name.summary'),
+      char: 'n',
+      required: false,
+    }),
+    file: Flags.file({
+      summary: messages.getMessage('flags.file.summary'),
+      char: 'f',
+      required: true,
+      exists: true,
+    }),
+    // it really could be most any valid ID
+    // eslint-disable-next-line sf-plugin/id-flag-suggestions
+    'parent-id': Flags.salesforceId({
+      summary: messages.getMessage('flags.parent-id.summary'),
+      char: 'i',
+      length: 'both',
+    }),
+  };
+
+  public async run(): Promise<ContentVersion> {
+    const { flags } = await this.parse(DataCreateFile);
+    const conn = flags['target-org'].getConnection(flags['api-version']);
+    const cv = await file2CV(conn, flags.file, flags.name);
+    this.logSuccess(messages.getMessage('createSuccess', [cv.ContentDocumentId]));
+
+    if (!flags['parent-id']) {
+      return cv;
+    }
+
+    const CDLReq = {
+      ContentDocumentId: cv.ContentDocumentId,
+      LinkedEntityId: flags['parent-id'],
+      ShareType: 'V',
+    } satisfies CDLCreateRequest;
+    try {
+      const CDLCreateResult = await conn.sobject('ContentDocumentLink').create(CDLReq);
+
+      if (CDLCreateResult.success) {
+        this.logSuccess(messages.getMessage('attachSuccess', [flags['parent-id']]));
+        return cv;
+      } else {
+        throw SfError.create({
+          message: messages.getMessage('attachFailure'),
+          data: CDLCreateResult.errors,
+        });
+      }
+    } catch (e) {
+      const error = SfError.wrap(e);
+      if (error.name === 'INSUFFICIENT_ACCESS_ON_CROSS_REFERENCE_ENTITY') {
+        error.actions = messages.getMessages('insufficientAccessActions');
+      }
+      throw error;
+    }
+  }
+}

--- a/src/dataSoqlQueryTypes.ts
+++ b/src/dataSoqlQueryTypes.ts
@@ -23,7 +23,7 @@ export type Field = {
   name: string;
   fields?: Field[];
   alias?: Optional<string>;
-}
+};
 
 /**
  * Type to define SoqlQuery results
@@ -55,7 +55,7 @@ export type DataPlanPart = {
   saveRefs: boolean;
   resolveRefs: boolean;
   files: Array<string | (DataPlanPart & { file: string })>;
-}
+};
 
 export type SObjectTreeFileContents = {
   records: SObjectTreeInput[];

--- a/src/export.ts
+++ b/src/export.ts
@@ -36,7 +36,7 @@ export type ExportConfig = {
   prefix?: string;
   conn: Connection;
   ux: Ux;
-}
+};
 
 /** refFromIdByType.get('account').get(someAccountId) => AccountRef1 */
 export type RefFromIdByType = Map<string, Map<string, string>>;

--- a/test/api/data/tree/exportApi.test.ts
+++ b/test/api/data/tree/exportApi.test.ts
@@ -13,7 +13,6 @@
 
 import fs from 'node:fs';
 
-
 import sinon from 'sinon';
 import { Connection, Messages, Org } from '@salesforce/core';
 import { AnyJson } from '@salesforce/ts-types';
@@ -222,7 +221,7 @@ function deepClone(obj: AnyJson) {
 describe('Export API', () => {
   const sandbox = sinon.createSandbox();
 
-  Messages.importMessagesDirectoryFromMetaUrl(import.meta.url)
+  Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
   const messages = Messages.loadMessages('@salesforce/plugin-data', 'exportApi');
   const testUsername = 'user@my.test';
 

--- a/test/commands/data/create/file.nut.ts
+++ b/test/commands/data/create/file.nut.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
+import { expect } from 'chai';
+import { SaveResult } from '@jsforce/jsforce-node';
+import { SoqlQueryResult } from '../../../../src/dataSoqlQueryTypes.js';
+import { ContentVersion } from '../../../../src/api/file/fileToContentVersion.js';
+
+describe('data create file NUTs', () => {
+  const filename = 'hi.txt';
+  let session: TestSession;
+  let acctId: string | undefined;
+  before(async () => {
+    session = await TestSession.create({
+      project: { name: 'dataCreateFile' },
+      scratchOrgs: [{ setDefault: true, edition: 'developer' }],
+      devhubAuthStrategy: 'AUTO',
+    });
+    // create one record in the org that we'll use to attach stuff to
+    acctId = execCmd<SaveResult>('data:create:record -s Account -v "Name=TestAccount" --json', {
+      ensureExitCode: 0,
+    }).jsonOutput?.result.id;
+    expect(acctId).to.be.a('string');
+    // make a file we can upload
+    await fs.promises.writeFile(path.join(session.project.dir, filename), 'hi');
+  });
+
+  after(async () => {
+    await session?.clean();
+  });
+
+  it('basic file upload', () => {
+    const command = `data:create:file --file ${filename} --json`;
+    const output = execCmd<ContentVersion>(command, { ensureExitCode: 0 }).jsonOutput?.result;
+    expect(output?.ContentDocumentId)
+      .to.be.a('string')
+      .match(/069\w{15}/);
+    expect(output?.Id)
+      .to.be.a('string')
+      .match(/068\w{15}/);
+    expect(output?.FileExtension).to.equal('txt');
+  });
+
+  it('file upload + attach with filename', () => {
+    const newName = 'newName.txt';
+    const command = `data:create:file --file ${filename} --parent-id ${acctId} --name ${newName} --json`;
+    const output = execCmd<ContentVersion>(command, { ensureExitCode: 0 }).jsonOutput?.result;
+    expect(output?.ContentDocumentId)
+      .to.be.a('string')
+      .match(/069\w{15}/);
+    expect(output?.Id)
+      .to.be.a('string')
+      .match(/068\w{15}/);
+    expect(output?.Title).to.equal(newName);
+
+    // make sure the file is attached to the record
+    const query = `SELECT Id FROM ContentDocumentLink WHERE LinkedEntityId='${acctId}' AND ContentDocumentId='${output?.ContentDocumentId}'`;
+    const result = execCmd<SoqlQueryResult['result']>(`data:query -q "${query}" --json`, { ensureExitCode: 0 })
+      .jsonOutput?.result;
+    expect(result?.totalSize).to.equal(1);
+  });
+});

--- a/test/commands/data/create/file.nut.ts
+++ b/test/commands/data/create/file.nut.ts
@@ -49,7 +49,7 @@ describe('data create file NUTs', () => {
 
   it('file upload + attach with filename', () => {
     const newName = 'newName.txt';
-    const command = `data:create:file --file ${filename} --parent-id ${acctId} --name ${newName} --json`;
+    const command = `data:create:file --file ${filename} --parent-id ${acctId} --title ${newName} --json`;
     const output = execCmd<ContentVersion>(command, { ensureExitCode: 0 }).jsonOutput?.result;
     expect(output?.ContentDocumentId)
       .to.be.a('string')

--- a/test/commands/data/dataSoqlQuery.nut.ts
+++ b/test/commands/data/dataSoqlQuery.nut.ts
@@ -17,14 +17,14 @@ export type QueryResult = {
   totalSize: number;
   done: boolean;
   records: Dictionary[];
-}
+};
 
 type QueryOptions = {
   json?: boolean;
   ensureExitCode?: number;
   bulk?: boolean;
   toolingApi?: boolean;
-}
+};
 
 function verifyRecordFields(accountRecord: Dictionary, fields: string[]) {
   expect(accountRecord).to.have.all.keys(...fields);

--- a/test/commands/data/record/dataRecord.nut.ts
+++ b/test/commands/data/record/dataRecord.nut.ts
@@ -15,14 +15,14 @@ type AccountRecord = {
   Id: string;
   Name: string;
   Phone: string;
-}
+};
 
 type ApexClassRecord = {
   Id: string;
   Name: string;
   Body: string;
   SymbolTable: Dictionary;
-}
+};
 
 const validateAccount = (output: string, recordId: string, accountName: string, phoneNumber: string): void => {
   assert.match(output, new RegExp(`Id:.*?${recordId}`, 'g'), 'Id should be present in output');

--- a/test/commands/force/data/bulk/dataBulk.nut.ts
+++ b/test/commands/force/data/bulk/dataBulk.nut.ts
@@ -19,7 +19,7 @@ let testSession: TestSession;
 type BulkStatus = {
   state: string;
   totalProcessingTime: number;
-}
+};
 
 /** Verify that the operation completed successfully and results are available before attempting to do stuff with the results */
 const isCompleted = async (cmd: string): Promise<void> => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,6 +1844,11 @@
   dependencies:
     tslib "^2.6.2"
 
+"@salesforce/types@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/types/-/types-1.1.0.tgz#22d13c84c22c036e20188c54e679e1710d4ae398"
+  integrity sha512-nYxyX9cR9A+ltELXHDJNKTjOgGrLj3URVUpAfpPlmEMjTYXkitz/4bJchIsN2r1Ud2kBcxUYtjvPOvKBnP9eiQ==
+
 "@sindresorhus/is@^4":
   version "4.6.0"
   resolved "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz"
@@ -4219,7 +4224,7 @@ form-data-encoder@^2.1.2:
 
 form-data@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
   integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
@@ -6854,16 +6859,7 @@ srcset@^5.0.0:
   resolved "https://registry.npmjs.org/srcset/-/srcset-5.0.0.tgz"
   integrity sha512-SqEZaAEhe0A6ETEa9O1IhSPC7MdvehZtCnTR0AftXk3QhY2UNgb+NApFOUPZILXk/YTDfFxMTNJOBpzrJsEdIA==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6922,14 +6918,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7467,7 +7456,7 @@ workerpool@6.2.1:
   resolved "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -7480,15 +7469,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
### What does this PR do?
adds a new command to upload files and optionally attach them to records
to replace a 3PP plugin command used by one of the commerce plugins

used `create` because of definition here https://github.com/salesforcecli/cli/wiki/Design-Guidelines-Common-Actions

### What issues does this PR fix or reference?
part of https://github.com/forcedotcom/cli/discussions/2344
related to https://github.com/forcedotcom/cli/discussions/2346