### PR TITLE
fix: remove extra logging error message

### DIFF
--- a/src/batcher.ts
+++ b/src/batcher.ts
@@ -211,7 +211,6 @@ export class Batcher {
       err.message.substr(batchIdIndex, 18),
     ]);
     this.ux.log('');
-    this.ux.log(message);
 
     process.exitCode = 69;
     return message;


### PR DESCRIPTION
### What does this PR do?
removes extra logging when timeout happens

currently : 
```bash
Batch #4 queued (Batch ID: 751DH000007u2B2YAI).

The operation timed out. Check the status with command:
sf force data bulk status -i 750DH0000068iqqYAA -b 751DH000007u2B2YAI
Bulk Upsert... Error
Error (69): The operation timed out. Check the status with command:
sf force data bulk status -i 750DH0000068iqqYAA -b 751DH000007u2B2YAI
```

after
```bash
Batch #5 queued (Batch ID: 751DH000007u2BbYAI).

Bulk Upsert... Error
Error (69): The operation timed out. Check the status with command:
sf force data bulk status -i 750DH0000068iqvYAA -b 751DH000007u2BRYAY
```
### What issues does this PR fix or reference?
@W-12354210@