### PR TITLE
fix(flags): no `dependsOn` boolean flags

### DIFF
--- a/src/commands/data/query.ts
+++ b/src/commands/data/query.ts
@@ -68,12 +68,24 @@ export class DataSoqlQueryCommand extends SfCommand<unknown> {
       unit: 'minutes',
       char: 'w',
       summary: messages.getMessage('flags.wait.summary'),
-      dependsOn: ['bulk'],
+      relationships: [
+        {
+          type: 'some',
+          // eslint-disable-next-line @typescript-eslint/require-await
+          flags: [{ name: 'bulk', when: async (flags): Promise<boolean> => Promise.resolve(flags['bulk'] === true) }],
+        },
+      ],
       exclusive: ['async'],
     }),
     async: Flags.boolean({
       summary: messages.getMessage('flags.async.summary'),
-      dependsOn: ['bulk'],
+      relationships: [
+        {
+          type: 'some',
+          // eslint-disable-next-line @typescript-eslint/require-await
+          flags: [{ name: 'bulk', when: async (flags): Promise<boolean> => Promise.resolve(flags['bulk'] === true) }],
+        },
+      ],
       exclusive: ['wait'],
     }),
     'all-rows': Flags.boolean({


### PR DESCRIPTION
### What does this PR do?

Updates `--wait` and `--async` flags in `data query` to use oclif's relationship feature instead of `dependsOn` a boolean flag.
Found by the new eslint rule:
https://github.com/salesforcecli/eslint-plugin-sf-plugin/actions/runs/10097996137/job/27924166840?pr=447

This introduces a behavior change because both flags were depending on `bulk` which has default value (`false`), so the following scenarios were allowed accidentally:

```
sf data query -q 'select name from account limit 1' --async
sf data query -q 'select name from account limit 1' --wait 10
```

due to how `data query` conditionally queried the records, these commands also didn't fail/affect output:
https://github.com/salesforcecli/plugin-data/blob/5386b61d746f47f51c0a50df5bbc13d71b8d5b0e/src/commands/data/query.ts#L112-L124

with this PR both examples will fail

TODO:
check telemetry, don't want to break a ton of users.

### What issues does this PR fix or reference?
@W-16320656@
