### PR TITLE
refactor: type-fix-for-result-format

### DIFF
--- a/messages/data.search.md
+++ b/messages/data.search.md
@@ -28,7 +28,7 @@ SOSL query to execute.
 
 # flags.result-format.summary
 
-Format to display the results, or to write to disk if you specify "csv"; the --json flag overrides this flag.
+Format to display the results, or to write to disk if you specify "csv".
 
 # flags.file.summary
 

--- a/src/commands/data/query.ts
+++ b/src/commands/data/query.ts
@@ -79,7 +79,7 @@ export class DataSoqlQueryCommand extends SfCommand<unknown> {
     'all-rows': Flags.boolean({
       summary: messages.getMessage('flags.all-rows.summary'),
     }),
-    'result-format': resultFormatFlag,
+    'result-format': resultFormatFlag(),
     perflog: perflogFlag,
   };
 

--- a/src/commands/data/query/resume.ts
+++ b/src/commands/data/query/resume.ts
@@ -36,7 +36,7 @@ export class BulkQueryReport extends SfCommand<unknown> {
     'target-org': { ...optionalOrgFlagWithDeprecations, summary: queryMessages.getMessage('flags.targetOrg.summary') },
     'api-version': orgApiVersionFlagWithDeprecations,
     loglevel,
-    'result-format': resultFormatFlag,
+    'result-format': resultFormatFlag(),
     'bulk-query-id': Flags.salesforceId({
       length: 18,
       char: 'i',

--- a/src/commands/data/search.ts
+++ b/src/commands/data/search.ts
@@ -35,6 +35,7 @@ export class DataSearchCommand extends SfCommand<SearchResult> {
     }),
     'result-format': resultFormatFlag({
       summary: messages.getMessage('flags.result-format.summary'),
+      exclusive: ['json'],
     }),
   };
 

--- a/src/commands/data/search.ts
+++ b/src/commands/data/search.ts
@@ -33,10 +33,9 @@ export class DataSearchCommand extends SfCommand<SearchResult> {
       summary: messages.getMessage('flags.file.summary'),
       exactlyOne: ['query', 'file'],
     }),
-    'result-format': {
-      ...resultFormatFlag,
+    'result-format': resultFormatFlag({
       summary: messages.getMessage('flags.result-format.summary'),
-    },
+    }),
   };
 
   public async run(): Promise<SearchResult> {
@@ -49,8 +48,7 @@ export class DataSearchCommand extends SfCommand<SearchResult> {
       if (flags['result-format'] !== 'json') this.spinner.start(messages.getMessage('queryRunningMessage'));
       const queryResult = await conn.search(queryString);
       if (!this.jsonEnabled()) {
-        // once we overrode result-format summary, undefined became a flag option, but the default is human
-        displaySearchResults(queryResult, flags['result-format'] ?? 'human');
+        displaySearchResults(queryResult, flags['result-format']);
       }
       return queryResult;
     } finally {

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -12,7 +12,7 @@ import {
   orgApiVersionFlagWithDeprecations,
   requiredOrgFlagWithDeprecations,
 } from '@salesforce/sf-plugins-core';
-import { formatTypes } from './reporters/query/reporters.js';
+import { FormatTypes, formatTypes } from './reporters/query/reporters.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-data', 'messages');
@@ -32,14 +32,14 @@ export const orgFlags = {
   loglevel,
 };
 
-export const resultFormatFlag = Flags.option({
+export const resultFormatFlag = Flags.custom<FormatTypes>({
   char: 'r',
   summary: messages.getMessage('flags.resultFormat.summary'),
   options: formatTypes,
   default: 'human',
   aliases: ['resultformat'],
   deprecateAliases: true,
-})();
+});
 
 export const prefixValidation = (i: string): Promise<string> => {
   if (i.includes('/') || i.includes('\\')) {

--- a/src/reporters/search/humanSearchReporter.ts
+++ b/src/reporters/search/humanSearchReporter.ts
@@ -20,7 +20,7 @@ export class HumanSearchReporter extends SearchReporter {
       // to find the columns of the query, parse the keys of the first record
       this.ux.table(records, Object.fromEntries(Object.keys(records[0]).map((k) => [k, { header: k }])), {
         'no-truncate': true,
-        title: `${type} Results`,
+        title: type,
       });
       this.ux.log();
     });

--- a/test/reporters/humanSearchReporter.test.ts
+++ b/test/reporters/humanSearchReporter.test.ts
@@ -58,9 +58,9 @@ describe('human search reporter', () => {
     // two objects, two tables
     expect(commandStubs.table.callCount).to.equal(2);
     expect(Object.keys(commandStubs.table.args[0][1])).to.deep.equal(['Name', 'Industry']);
-    expect(commandStubs.table.args[0][2]?.title).to.equal('Account Results');
+    expect(commandStubs.table.args[0][2]?.title).to.equal('Account');
     expect(Object.keys(commandStubs.table.args[1][1])).to.deep.equal(['FirstName', 'LastName', 'Department']);
-    expect(commandStubs.table.args[1][2]?.title).to.equal('Contact Results');
+    expect(commandStubs.table.args[1][2]?.title).to.equal('Contact');
   });
 
   it('will not print a table for no results', () => {


### PR DESCRIPTION
### What does this PR do?
- use oclif's Flags.custom to get a typed option flag that doesn't need ...spread to override the summary
- explicitly disallow `--result-format` with `--json`

### What issues does this PR fix or reference?
