### PR TITLE
fix: bump oclif/mso

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
   },
   "dependencies": {
     "@jsforce/jsforce-node": "^3.5.1",
-    "@oclif/multi-stage-output": "^0.3.0",
+    "@oclif/multi-stage-output": "^0.7.5",
     "@salesforce/core": "^8.6.1",
     "@salesforce/kit": "^3.2.2",
     "@salesforce/sf-plugins-core": "^11.3.10",

--- a/src/commands/data/export/bulk.ts
+++ b/src/commands/data/export/bulk.ts
@@ -163,7 +163,7 @@ export default class DataExportBulk extends SfCommand<DataExportBulkResult> {
       });
 
       job.on('error', (err) => {
-        ms.stop(err as Error);
+        ms.stop('failed');
         throw err;
       });
 
@@ -196,8 +196,7 @@ export default class DataExportBulk extends SfCommand<DataExportBulkResult> {
           filePath: flags['output-file'],
         };
       } catch (err) {
-        const error = err as Error;
-        ms.stop(error);
+        ms.stop('failed');
         throw err;
       }
     }
@@ -215,8 +214,8 @@ export default class DataExportBulk extends SfCommand<DataExportBulkResult> {
       },
     });
 
-    queryJob.on('error', (error: Error) => {
-      ms.stop(error);
+    queryJob.on('error', () => {
+      ms.stop('failed');
     });
 
     queryJob.on('open', (jobInfo: QueryJobInfoV2) => {
@@ -250,9 +249,8 @@ export default class DataExportBulk extends SfCommand<DataExportBulkResult> {
         filePath: flags['output-file'],
       };
     } catch (err) {
-      const error = err as Error;
-      ms.stop(error);
-      throw error;
+      ms.stop('failed');
+      throw err;
     }
   }
 }

--- a/src/commands/data/export/resume.ts
+++ b/src/commands/data/export/resume.ts
@@ -79,6 +79,11 @@ export default class DataExportResume extends SfCommand<DataExportResumeResult> 
       ms.goto('exporting records', { state: jobInfo.state });
     });
 
+    queryJob.on('error', (err) => {
+      ms.stop('failed');
+      throw err;
+    });
+
     try {
       const jobInfo = await exportRecords(resumeOpts.options.connection, queryJob, resumeOpts.outputInfo);
 
@@ -91,9 +96,8 @@ export default class DataExportResume extends SfCommand<DataExportResumeResult> 
         filePath: resumeOpts.outputInfo.filePath,
       };
     } catch (err) {
-      const error = err as Error;
-      ms.stop(error);
-      throw error;
+      ms.stop('failed');
+      throw err;
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1596,18 +1596,18 @@
     wordwrap "^1.0.0"
     wrap-ansi "^7.0.0"
 
-"@oclif/multi-stage-output@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@oclif/multi-stage-output/-/multi-stage-output-0.3.0.tgz#2d74763bd2215c61ec1cd53faf3138328d50122d"
-  integrity sha512-7pMD3CoXfS9/hEWzZ1b8GZb3leSNWENsMJS7uYTX0XqTXlrzh+eYvFHYcJh9bEkIw67LKjFfGGIwXbotdhtZKg==
+"@oclif/multi-stage-output@^0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@oclif/multi-stage-output/-/multi-stage-output-0.7.5.tgz#e4ba79995e261912b52b5a0701ab2f4ccddebba4"
+  integrity sha512-9DSPryrL6Qx7jWz7BGBdSyokmUUbrp8z3kRZpfIbA0vqZ/zqYDdW2tO2hlplb74Sr8FUiiwE0FcvRTYZWEmb9Q==
   dependencies:
     "@oclif/core" "^4"
-    "@types/react" "^18.3.3"
-    change-case "^5.4.4"
+    "@types/react" "^18.3.11"
     cli-spinners "^2"
     figures "^6.1.0"
     ink "^5.0.1"
     react "^18.3.1"
+    wrap-ansi "^9.0.0"
 
 "@oclif/plugin-command-snapshot@^5.2.15":
   version "5.2.15"
@@ -2476,10 +2476,10 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.12.tgz#12bb1e2be27293c1406acb6af1c3f3a1481d98c6"
   integrity sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==
 
-"@types/react@^18.3.3":
-  version "18.3.3"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.3.tgz#9679020895318b0915d7a3ab004d92d33375c45f"
-  integrity sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==
+"@types/react@^18.3.11":
+  version "18.3.11"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.11.tgz#9d530601ff843ee0d7030d4227ea4360236bd537"
+  integrity sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
@@ -7014,7 +7014,16 @@ stack-utils@^2.0.6:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -7082,7 +7091,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7646,7 +7662,7 @@ workerpool@^6.5.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -7659,6 +7675,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
### What does this PR do?

bump oclif/mso, update calls to `ms.stop` (no longer takes an error).

no function changes, example trying to export records with a bad query:
![Screenshot 2024-10-09 at 3 56 42 PM](https://github.com/user-attachments/assets/c6485f55-2a95-4613-96b2-3b3489d37a2e)


### What issues does this PR fix or reference?
[skip-validate-pr]