### PR TITLE
feat: add `import bulk/resume` commands

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -142,7 +142,7 @@
     "command": "data:import:bulk",
     "flagAliases": [],
     "flagChars": ["a", "f", "o", "s", "w"],
-    "flags": ["api-version", "async", "file", "flags-dir", "json", "sobject", "target-org", "wait"],
+    "flags": ["api-version", "async", "file", "flags-dir", "json", "line-ending", "sobject", "target-org", "wait"],
     "plugin": "@salesforce/plugin-data"
   },
   {

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -139,6 +139,14 @@
   },
   {
     "alias": [],
+    "command": "data:import:bulk",
+    "flagAliases": [],
+    "flagChars": ["a", "f", "o", "s", "w"],
+    "flags": ["api-version", "async", "file", "flags-dir", "json", "sobject", "target-org", "wait"],
+    "plugin": "@salesforce/plugin-data"
+  },
+  {
+    "alias": [],
     "command": "data:import:legacy:tree",
     "flagAliases": ["apiversion", "confighelp", "contenttype", "sobjecttreefiles", "targetusername", "u"],
     "flagChars": ["c", "f", "o", "p"],
@@ -153,6 +161,14 @@
       "plan",
       "target-org"
     ],
+    "plugin": "@salesforce/plugin-data"
+  },
+  {
+    "alias": [],
+    "command": "data:import:resume",
+    "flagAliases": [],
+    "flagChars": ["i", "w"],
+    "flags": ["api-version", "flags-dir", "job-id", "json", "use-most-recent", "wait"],
     "plugin": "@salesforce/plugin-data"
   },
   {

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -168,7 +168,7 @@
     "command": "data:import:resume",
     "flagAliases": [],
     "flagChars": ["i", "w"],
-    "flags": ["api-version", "flags-dir", "job-id", "json", "use-most-recent", "wait"],
+    "flags": ["flags-dir", "job-id", "json", "use-most-recent", "wait"],
     "plugin": "@salesforce/plugin-data"
   },
   {

--- a/messages/data.import.bulk.md
+++ b/messages/data.import.bulk.md
@@ -1,37 +1,38 @@
 # summary
 
-Bulk import records to an org from a CSV file. Uses Bulk API 2.0.
+Bulk import records into a Salesforce object from a CSV file. Uses Bulk API 2.0.
 
 # description
 
-You can use this command to import millions of records to an org from a CSV file.
+You can use this command to import millions of records into the object from a file in comma-separated values (CSV) format.
 
-All the records in the CSV file must be for the same object, you specify the object being imported via the `--sobject` flag.
+All the records in the CSV file must be for the same Salesforce object. Specify the object with the `--sobject` flag.
 
-More info about how to prepare CSV files:
-https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/datafiles_prepare_csv.htm
+Bulk imports can take a while, depending on how many records are in the CSV file. If the command times out, or you specified the --async flag, the command displays the job ID. To see the status and get the results of the job, run "sf data import resume" and pass the job ID to the --job-id flag.
+
+For information and examples about how to prepare your CSV files, see "Prepare Data to Ingest" in the "Bulk API 2.0 and Bulk API Developer Guide" (https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/datafiles_prepare_data.htm).
 
 # examples
 
-- Import Account records from a CSV-formatted file into an org.
+- Import Account records from a CSV-formatted file into an org with alias "my-scratch"; if the import doesn't complete in 10 minutes, the command ends and displays a job ID:
 
   <%= config.bin %> <%= command.id %> --file accounts.csv --sobject Account --wait 10 --target-org my-scratch
 
-- Import asynchronously; the command immediately returns a job ID that you then pass to the "sf data import resume" command:
+- Import asynchronously and use the default org; the command immediately returns a job ID that you then pass to the "sf data import resume" command:
 
-  <%= config.bin %> <%= command.id %> --file accounts.csv --sobject Account --async --target-org my-scratch
+  <%= config.bin %> <%= command.id %> --file accounts.csv --sobject Account --async
 
 # flags.async.summary
 
-Run the command asynchronously.
+Don't wait for the command to complete.
 
 # flags.file.summary
 
-CSV file that contains the fields of the object to import.
+CSV file that contains the Salesforce object records you want to import.
 
 # flags.sobject.summary
 
-API name of the Salesforce object, either standard or custom, that you want to import to the org.
+API name of the Salesforce object, either standard or custom, into which you're importing records.
 
 # flags.wait.summary
 
@@ -55,20 +56,24 @@ Run "sf data import resume --job-id %s" to resume it.
 
 Job finished being processed but failed to import %s records.
 
-To review the details of this job, run:
+To review the details of this job, run this command:
+
 sf org open --target-org %s --path "/lightning/setup/AsyncApiJobStatus/page?address=%2F%s"
 
 # error.jobFailed
 
 Job failed to be processed due to:
+
 %s
 
-To review the details of this job, run:
+To review the details of this job, run this command:
+
 sf org open --target-org %s --path "/lightning/setup/AsyncApiJobStatus/page?address=%2F%s"
 
 # error.jobAborted
 
 Job has been aborted.
 
-To review the details of this job, run:
+To review the details of this job, run this command:
+
 sf org open --target-org %s --path "/lightning/setup/AsyncApiJobStatus/page?address=%2F%s"

--- a/messages/data.import.bulk.md
+++ b/messages/data.import.bulk.md
@@ -1,0 +1,70 @@
+# summary
+
+Bulk import records to an org from a CSV file. Uses Bulk API 2.0.
+
+# description
+
+You can use this command to import millions of records to an org from a CSV file.
+
+All the records in the CSV file must be for the same object, you specify the object being imported via the `--sobject` flag.
+
+More info about how to prepare CSV files:
+https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/datafiles_prepare_csv.htm
+
+# examples
+
+- Import Account records from a CSV-formatted file into an org.
+
+  <%= config.bin %> <%= command.id %> --file accounts.csv --sobject Account --wait 10 --target-org my-scratch
+
+- Import asynchronously; the command immediately returns a job ID that you then pass to the "sf data import resume" command:
+
+  <%= config.bin %> <%= command.id %> --file accounts.csv --sobject Account --async --target-org my-scratch
+
+# flags.async.summary
+
+Run the command asynchronously.
+
+# flags.file.summary
+
+CSV file that contains the fields of the object to import.
+
+# flags.sobject.summary
+
+API name of the Salesforce object, either standard or custom, that you want to import to the org.
+
+# flags.wait.summary
+
+Time to wait for the command to finish, in minutes.
+
+# export.resume
+
+Run "sf data import resume --job-id %s" to resume the operation.
+
+# error.timeout
+
+The operation timed out after %s minutes.
+
+Run "sf data import resume --job-id %s" to resume it.
+
+# error.failedRecordDetails
+
+Job finished being processed but failed to import %s records.
+
+To review the details of this job, run:
+sf org open --target-org %s --path "/lightning/setup/AsyncApiJobStatus/page?address=%2F%s"
+
+# error.jobFailed
+
+Job failed to be processed due to:
+%s
+
+To review the details of this job, run:
+sf org open --target-org %s --path "/lightning/setup/AsyncApiJobStatus/page?address=%2F%s"
+
+# error.jobAborted
+
+Job has been aborted.
+
+To review the details of this job, run:
+sf org open --target-org %s --path "/lightning/setup/AsyncApiJobStatus/page?address=%2F%s"

--- a/messages/data.import.bulk.md
+++ b/messages/data.import.bulk.md
@@ -37,6 +37,10 @@ API name of the Salesforce object, either standard or custom, that you want to i
 
 Time to wait for the command to finish, in minutes.
 
+# flags.line-ending.summary
+
+Line ending used in the CSV file. Default value on Windows is `CRLF`; on macOS and Linux it's `LR`.
+
 # export.resume
 
 Run "sf data import resume --job-id %s" to resume the operation.

--- a/messages/data.import.resume.md
+++ b/messages/data.import.resume.md
@@ -4,11 +4,11 @@ Resume a bulk import job that you previously started. Uses Bulk API 2.0.
 
 # description
 
-The command uses the job ID returned by the "sf data import bulk" command or the most recently-run bulk import job.
+When the original "sf data import bulk" command either times out or is run with the --async flag, it displays a job ID. To see the status and get the results of the bulk import, run this command by either passing it the job ID or using the --use-most-recent flag to specify the most recent bulk import job.
 
 # examples
 
-- Resume a bulk import job from your default org using an ID:
+- Resume a bulk import job to your default org using an ID:
 
   <%= config.bin %> <%= command.id %> --job-id 750xx000000005sAAA
 
@@ -32,7 +32,8 @@ Time to wait for the command to finish, in minutes.
 
 Job finished being processed but failed to import %s records.
 
-To review the details of this job, run:
+To review the details of this job, run this command:
+
 sf org open --target-org %s --path "/lightning/setup/AsyncApiJobStatus/page?address=%2F%s"
 
 # error.timeout
@@ -44,14 +45,17 @@ Try re-running "sf data import resume --job-id %s" with a bigger wait time.
 # error.jobFailed
 
 Job failed to be processed due to:
+
 %s
 
-To review the details of this job, run:
+To review the details of this job, run this command:
+
 sf org open --target-org %s --path "/lightning/setup/AsyncApiJobStatus/page?address=%2F%s"
 
 # error.jobAborted
 
 Job has been aborted.
 
-To review the details of this job, run:
+To review the details of this job, run this command:
+
 sf org open --target-org %s --path "/lightning/setup/AsyncApiJobStatus/page?address=%2F%s"

--- a/messages/data.import.resume.md
+++ b/messages/data.import.resume.md
@@ -1,26 +1,32 @@
 # summary
 
-Summary of a command.
+Resume a bulk import job that you previously started. Uses Bulk API 2.0.
 
 # description
 
-More information about a command. Don't repeat the summary.
+The command uses the job ID returned by the "sf data import bulk" command or the most recently-run bulk import job.
 
 # examples
 
-- <%= config.bin %> <%= command.id %>
+- Resume a bulk import job from your default org using an ID:
+
+  <%= config.bin %> <%= command.id %> --job-id 750xx000000005sAAA
+
+- Resume the most recently run bulk import job for an org with alias my-scratch:
+
+  <%= config.bin %> <%= command.id %> --use-most-recent --target-org my-scratch
 
 # flags.use-most-recent.summary
 
-Summary for use-most-recent.
+Use the job ID of the bulk import job that was most recently run.
 
 # flags.job-id.summary
 
-Summary for job-id.
+Job ID of the bulk import.
 
 # flags.wait.summary
 
-Summary for wait.
+Time to wait for the command to finish, in minutes.
 
 # error.failedRecordDetails
 

--- a/messages/data.import.resume.md
+++ b/messages/data.import.resume.md
@@ -1,0 +1,51 @@
+# summary
+
+Summary of a command.
+
+# description
+
+More information about a command. Don't repeat the summary.
+
+# examples
+
+- <%= config.bin %> <%= command.id %>
+
+# flags.use-most-recent.summary
+
+Summary for use-most-recent.
+
+# flags.job-id.summary
+
+Summary for job-id.
+
+# flags.wait.summary
+
+Summary for wait.
+
+# error.failedRecordDetails
+
+Job finished being processed but failed to import %s records.
+
+To review the details of this job, run:
+sf org open --target-org %s --path "/lightning/setup/AsyncApiJobStatus/page?address=%2F%s"
+
+# error.timeout
+
+The operation timed out after %s minutes.
+
+Try re-running "sf data import resume --job-id %s" with a bigger wait time.
+
+# error.jobFailed
+
+Job failed to be processed due to:
+%s
+
+To review the details of this job, run:
+sf org open --target-org %s --path "/lightning/setup/AsyncApiJobStatus/page?address=%2F%s"
+
+# error.jobAborted
+
+Job has been aborted.
+
+To review the details of this job, run:
+sf org open --target-org %s --path "/lightning/setup/AsyncApiJobStatus/page?address=%2F%s"

--- a/messages/messages.md
+++ b/messages/messages.md
@@ -54,7 +54,7 @@ The bulk request id must be supplied when not looking for most recent cache entr
 
 # error.bulkRequestIdNotFound
 
-Could not find a cache entry for job ID %s
+Could not find a cache entry for job ID %s.
 
 # error.missingCacheEntryError
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
             "description": "Get a single record."
           },
           "import": {
-            "description": "Import data to your org."
+            "description": "Import data to your org.",
+            "external": true
           },
           "query": {
             "description": "Query records."

--- a/src/bulkDataRequestCache.ts
+++ b/src/bulkDataRequestCache.ts
@@ -188,6 +188,28 @@ export class BulkUpsertRequestCache extends BulkDataRequestCache {
   }
 }
 
+export class BulkImportRequestCache extends BulkDataRequestCache {
+  public static getDefaultOptions(): TTLConfig.Options {
+    return {
+      isGlobal: true,
+      isState: true,
+      filename: BulkImportRequestCache.getFileName(),
+      stateFolder: Global.SF_STATE_FOLDER,
+      ttl: Duration.days(7),
+    };
+  }
+
+  public static getFileName(): string {
+    return 'bulk-data-import-cache.json';
+  }
+
+  public static async unset(key: string): Promise<void> {
+    const cache = await BulkImportRequestCache.create();
+    cache.unset(key);
+    await cache.write();
+  }
+}
+
 export class BulkExportRequestCache extends TTLConfig<TTLConfig.Options, BulkExportCacheConfig> {
   public static getDefaultOptions(): TTLConfig.Options {
     return {

--- a/src/commands/data/import/bulk.ts
+++ b/src/commands/data/import/bulk.ts
@@ -75,11 +75,11 @@ export default class DataImportBulk extends SfCommand<DataImportBulkResult> {
 
     const ms = new MultiStageOutput<JobInfoV2>({
       jsonEnabled: flags.json ?? false,
-      stages: async ? ['creating ingest job'] : ['creating ingest job', 'processing the job'],
+      stages: async ? ['Creating ingest job'] : ['Creating ingest job', 'Processing the job'],
       title: async ? 'Importing data (async)' : 'Importing data',
       stageSpecificBlock: [
         {
-          stage: 'processing the job',
+          stage: 'Processing the job',
           label: 'Processed records',
           type: 'dynamic-key-value',
           get: (data): string | undefined => {
@@ -89,7 +89,7 @@ export default class DataImportBulk extends SfCommand<DataImportBulkResult> {
           },
         },
         {
-          stage: 'processing the job',
+          stage: 'Processing the job',
           label: 'Successful records',
           type: 'dynamic-key-value',
           get: (data): string | undefined => {
@@ -101,7 +101,7 @@ export default class DataImportBulk extends SfCommand<DataImportBulkResult> {
           },
         },
         {
-          stage: 'processing the job',
+          stage: 'Processing the job',
           label: 'Failed records',
           type: 'dynamic-key-value',
           get: (data): string | undefined => {
@@ -133,11 +133,11 @@ export default class DataImportBulk extends SfCommand<DataImportBulkResult> {
     });
 
     if (async) {
-      ms.goto('creating ingest job');
+      ms.goto('Creating ingest job');
 
       const job = await createIngestJob(conn, flags.file, flags.sobject, flags['line-ending']);
 
-      ms.goto('creating ingest job', job.getInfo());
+      ms.goto('Creating ingest job', job.getInfo());
       ms.stop();
 
       const cache = await BulkImportRequestCache.create();
@@ -153,10 +153,10 @@ export default class DataImportBulk extends SfCommand<DataImportBulkResult> {
     // synchronous flow
     const job = await createIngestJob(conn, flags.file, flags.sobject, flags['line-ending']);
 
-    ms.goto('processing the job');
+    ms.goto('Processing the job');
 
     job.on('inProgress', (res: JobInfoV2) => {
-      ms.goto('processing the job', res);
+      ms.goto('Processing the job', res);
     });
 
     try {
@@ -165,7 +165,7 @@ export default class DataImportBulk extends SfCommand<DataImportBulkResult> {
       const jobInfo = job.getInfo();
 
       // send last data update so job status/num. of records processed/failed represent the last update
-      ms.goto('processing the job', jobInfo);
+      ms.goto('Processing the job', jobInfo);
 
       if (jobInfo.numberRecordsFailed) {
         ms.stop('failed');
@@ -189,7 +189,7 @@ export default class DataImportBulk extends SfCommand<DataImportBulkResult> {
       const jobInfo = await job.check();
 
       // send last data update so job status/num. of records processed/failed represent the last update
-      ms.goto('processing the job', jobInfo);
+      ms.goto('Processing the job', jobInfo);
 
       if (err instanceof Error && err.name === 'JobPollingTimeout') {
         ms.stop('paused');

--- a/src/commands/data/import/bulk.ts
+++ b/src/commands/data/import/bulk.ts
@@ -35,6 +35,7 @@ export default class DataImportBulk extends SfCommand<DataImportBulkResult> {
     async: Flags.boolean({
       summary: messages.getMessage('flags.async.summary'),
       char: 'a',
+      exclusive: ['wait'],
     }),
     file: Flags.file({
       summary: messages.getMessage('flags.file.summary'),
@@ -52,6 +53,7 @@ export default class DataImportBulk extends SfCommand<DataImportBulkResult> {
       summary: messages.getMessage('flags.wait.summary'),
       char: 'w',
       unit: 'minutes',
+      exclusive: ['async'],
     }),
     'target-org': Flags.requiredOrg(),
     'line-ending': Flags.option({

--- a/src/commands/data/import/bulk.ts
+++ b/src/commands/data/import/bulk.ts
@@ -74,7 +74,7 @@ export default class DataImportBulk extends SfCommand<DataImportBulkResult> {
     const baseUrl = flags['target-org'].getField<string>(Org.Fields.INSTANCE_URL).toString();
 
     const ms = new MultiStageOutput<JobInfoV2>({
-      jsonEnabled: flags.json ?? false,
+      jsonEnabled: this.jsonEnabled(),
       stages: async ? ['Creating ingest job'] : ['Creating ingest job', 'Processing the job'],
       title: async ? 'Importing data (async)' : 'Importing data',
       stageSpecificBlock: [

--- a/src/commands/data/import/bulk.ts
+++ b/src/commands/data/import/bulk.ts
@@ -12,6 +12,7 @@ import { Connection, Messages, Org } from '@salesforce/core';
 import { Duration } from '@salesforce/kit';
 import { IngestJobV2 } from '@jsforce/jsforce-node/lib/api/bulk2.js';
 import { Schema } from '@jsforce/jsforce-node';
+import { ensureString } from '@salesforce/ts-types';
 import { BulkImportRequestCache } from '../../../bulkDataRequestCache.js';
 import { BulkImportStages } from '../../../ux/bulkImportStages.js';
 
@@ -89,7 +90,7 @@ export default class DataImportBulk extends SfCommand<DataImportBulkResult> {
       stages.stop();
 
       const cache = await BulkImportRequestCache.create();
-      await cache.createCacheEntryForRequest(job.id, conn.getUsername(), conn.getApiVersion());
+      await cache.createCacheEntryForRequest(job.id, ensureString(conn.getUsername()), conn.getApiVersion());
 
       this.log(messages.getMessage('export.resume', [job.id]));
 

--- a/src/commands/data/import/bulk.ts
+++ b/src/commands/data/import/bulk.ts
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2024, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as fs from 'node:fs';
+import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { MultiStageOutput } from '@oclif/multi-stage-output';
+import { Connection, Messages, Org } from '@salesforce/core';
+import { Duration } from '@salesforce/kit';
+import terminalLink from 'terminal-link';
+import { IngestJobV2, JobInfoV2 } from '@jsforce/jsforce-node/lib/api/bulk2.js';
+import { Schema } from '@jsforce/jsforce-node';
+import { BulkImportRequestCache } from '../../../bulkDataRequestCache.js';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+const messages = Messages.loadMessages('@salesforce/plugin-data', 'data.import.bulk');
+
+export type DataImportBulkResult = {
+  jobId: string;
+  processedRecords?: number;
+  successfulRecords?: number;
+  failedRecords?: number;
+};
+
+export default class DataImportBulk extends SfCommand<DataImportBulkResult> {
+  public static readonly summary = messages.getMessage('summary');
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessages('examples');
+
+  public static readonly flags = {
+    async: Flags.boolean({
+      summary: messages.getMessage('flags.async.summary'),
+      char: 'a',
+    }),
+    file: Flags.file({
+      summary: messages.getMessage('flags.file.summary'),
+      char: 'f',
+      required: true,
+      exists: true,
+    }),
+    sobject: Flags.string({
+      summary: messages.getMessage('flags.sobject.summary'),
+      char: 's',
+      required: true,
+    }),
+    'api-version': Flags.orgApiVersion(),
+    wait: Flags.duration({
+      summary: messages.getMessage('flags.wait.summary'),
+      char: 'w',
+      unit: 'minutes',
+    }),
+    'target-org': Flags.requiredOrg(),
+    // TODO: add --line-ending flag
+  };
+
+  public async run(): Promise<DataImportBulkResult> {
+    const { flags } = await this.parse(DataImportBulk);
+
+    const conn = flags['target-org'].getConnection(flags['api-version']);
+
+    const timeout = flags.async ? Duration.minutes(0) : flags.wait ?? Duration.minutes(0);
+    const async = timeout.milliseconds === 0;
+
+    const baseUrl = flags['target-org'].getField<string>(Org.Fields.INSTANCE_URL).toString();
+
+    const ms = new MultiStageOutput<JobInfoV2>({
+      jsonEnabled: flags.json ?? false,
+      stages: async ? ['creating ingest job'] : ['creating ingest job', 'processing the job'],
+      title: async ? 'Importing data (async)' : 'Importing data',
+      stageSpecificBlock: [
+        {
+          stage: 'processing the job',
+          label: 'Processed records',
+          type: 'dynamic-key-value',
+          get: (data): string | undefined => {
+            if (data?.numberRecordsProcessed) {
+              return data.numberRecordsProcessed.toString();
+            }
+          },
+        },
+        {
+          stage: 'processing the job',
+          label: 'Successful records',
+          type: 'dynamic-key-value',
+          get: (data): string | undefined => {
+            const numberRecordsFailed = data?.numberRecordsFailed ?? 0;
+
+            if (data?.numberRecordsProcessed) {
+              return (data.numberRecordsProcessed - numberRecordsFailed).toString();
+            }
+          },
+        },
+        {
+          stage: 'processing the job',
+          label: 'Failed records',
+          type: 'dynamic-key-value',
+          get: (data): string | undefined => {
+            if (data?.numberRecordsFailed) {
+              return data.numberRecordsFailed.toString();
+            }
+          },
+        },
+      ],
+      postStagesBlock: [
+        {
+          label: 'Status',
+          type: 'dynamic-key-value',
+          bold: true,
+          get: (data) => data?.state,
+        },
+        {
+          label: 'Job Id',
+          type: 'dynamic-key-value',
+          bold: true,
+          get: (data) =>
+            data?.id &&
+            terminalLink(
+              data.id,
+              `${baseUrl}/lightning/setup/AsyncApiJobStatus/page?address=${encodeURIComponent(`/${data.id}`)}`
+            ),
+        },
+      ],
+    });
+
+    if (async) {
+      ms.goto('creating ingest job');
+
+      const job = await createIngestJob(conn, flags.file, flags.sobject);
+
+      ms.goto('creating ingest job', job.getInfo());
+      ms.stop();
+
+      const cache = await BulkImportRequestCache.create();
+      await cache.createCacheEntryForRequest(job.id, conn.getUsername(), conn.getApiVersion());
+
+      this.log(messages.getMessage('export.resume', [job.id]));
+
+      return {
+        jobId: job.id,
+      };
+    }
+
+    // synchronous flow
+    const job = await createIngestJob(conn, flags.file, flags.sobject);
+
+    ms.goto('processing the job');
+
+    job.on('inProgress', (res: JobInfoV2) => {
+      ms.goto('processing the job', res);
+    });
+
+    try {
+      await job.poll(5000, timeout.milliseconds);
+
+      const jobInfo = job.getInfo();
+
+      // send last data update so job status/num. of records processed/failed represent the last update
+      ms.goto('processing the job', jobInfo);
+
+      if (jobInfo.numberRecordsFailed) {
+        ms.stop('failed');
+        // TODO: replace this msg to point to `sf data bulk results` when it's added (W-12408034)
+        throw messages.createError('error.failedRecordDetails', [
+          jobInfo.numberRecordsFailed,
+          conn.getUsername(),
+          job.id,
+        ]);
+      }
+
+      ms.stop();
+
+      return {
+        jobId: jobInfo.id,
+        processedRecords: jobInfo.numberRecordsProcessed,
+        successfulRecords: jobInfo.numberRecordsProcessed - (jobInfo.numberRecordsFailed ?? 0),
+        failedRecords: jobInfo.numberRecordsFailed,
+      };
+    } catch (err) {
+      const jobInfo = await job.check();
+
+      // send last data update so job status/num. of records processed/failed represent the last update
+      ms.goto('processing the job', jobInfo);
+
+      if (err instanceof Error && err.name === 'JobPollingTimeout') {
+        ms.stop('paused');
+        throw messages.createError('error.timeout', [timeout.minutes, job.id]);
+      }
+
+      if (jobInfo.state === 'Failed') {
+        ms.stop('failed');
+        throw messages.createError(
+          'error.jobFailed',
+          [jobInfo.errorMessage, conn.getUsername(), job.id],
+          [],
+          err as Error
+        );
+      }
+
+      if (jobInfo.state === 'Aborted') {
+        ms.stop('failed');
+        // TODO: replace this msg to point to `sf data bulk results` when it's added (W-12408034)
+        throw messages.createError('error.jobAborted', [conn.getUsername(), job.id], [], err as Error);
+      }
+
+      throw err;
+    }
+  }
+}
+
+/**
+ * Create an ingest job, upload data and mark it as ready for processing
+ *
+ * */
+async function createIngestJob(conn: Connection, csvFile: string, object: string): Promise<IngestJobV2<Schema>> {
+  const job = conn.bulk2.createJob({
+    operation: 'insert',
+    object,
+  });
+
+  // create the job in the org
+  await job.open();
+
+  // upload data
+  await job.uploadData(fs.createReadStream(csvFile));
+
+  // mark the job to be ready to be processed
+  await job.close();
+
+  return job;
+}

--- a/src/commands/data/import/bulk.ts
+++ b/src/commands/data/import/bulk.ts
@@ -168,7 +168,7 @@ export default class DataImportBulk extends SfCommand<DataImportBulkResult> {
       ms.goto('Processing the job', jobInfo);
 
       if (jobInfo.numberRecordsFailed) {
-        ms.stop('failed');
+        ms.error();
         // TODO: replace this msg to point to `sf data bulk results` when it's added (W-12408034)
         throw messages.createError('error.failedRecordDetails', [
           jobInfo.numberRecordsFailed,
@@ -197,7 +197,7 @@ export default class DataImportBulk extends SfCommand<DataImportBulkResult> {
       }
 
       if (jobInfo.state === 'Failed') {
-        ms.stop('failed');
+        ms.error();
         throw messages.createError(
           'error.jobFailed',
           [jobInfo.errorMessage, conn.getUsername(), job.id],
@@ -207,7 +207,7 @@ export default class DataImportBulk extends SfCommand<DataImportBulkResult> {
       }
 
       if (jobInfo.state === 'Aborted') {
-        ms.stop('failed');
+        ms.error();
         // TODO: replace this msg to point to `sf data bulk results` when it's added (W-12408034)
         throw messages.createError('error.jobAborted', [conn.getUsername(), job.id], [], err as Error);
       }

--- a/src/commands/data/import/resume.ts
+++ b/src/commands/data/import/resume.ts
@@ -30,11 +30,13 @@ export default class DataImportResume extends SfCommand<DataImportResumeResult> 
   public static readonly flags = {
     'use-most-recent': Flags.boolean({
       summary: messages.getMessage('flags.use-most-recent.summary'),
+      exclusive: ['job-id'],
     }),
     'job-id': Flags.salesforceId({
       summary: messages.getMessage('flags.job-id.summary'),
       char: 'i',
       length: 18,
+      exclusive: ['use-most-recent'],
     }),
     wait: Flags.duration({
       char: 'w',

--- a/src/commands/data/import/resume.ts
+++ b/src/commands/data/import/resume.ts
@@ -31,7 +31,6 @@ export default class DataImportResume extends SfCommand<DataImportResumeResult> 
     'use-most-recent': Flags.boolean({
       summary: messages.getMessage('flags.use-most-recent.summary'),
     }),
-    'api-version': Flags.orgApiVersion(),
     'job-id': Flags.salesforceId({
       summary: messages.getMessage('flags.job-id.summary'),
       char: 'i',

--- a/src/commands/data/import/resume.ts
+++ b/src/commands/data/import/resume.ts
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { Messages } from '@salesforce/core';
+import { MultiStageOutput } from '@oclif/multi-stage-output';
+import terminalLink from 'terminal-link';
+import { JobInfoV2 } from '@jsforce/jsforce-node/lib/api/bulk2.js';
+import { BulkImportRequestCache } from '../../../bulkDataRequestCache.js';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+const messages = Messages.loadMessages('@salesforce/plugin-data', 'data.import.resume');
+
+export type DataImportResumeResult = {
+  jobId: string;
+  processedRecords?: number;
+  successfulRecords?: number;
+  failedRecords?: number;
+};
+
+export default class DataImportResume extends SfCommand<DataImportResumeResult> {
+  public static readonly summary = messages.getMessage('summary');
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessages('examples');
+
+  public static readonly flags = {
+    'use-most-recent': Flags.boolean({
+      summary: messages.getMessage('flags.use-most-recent.summary'),
+    }),
+    'api-version': Flags.orgApiVersion(),
+    'job-id': Flags.salesforceId({
+      summary: messages.getMessage('flags.job-id.summary'),
+      char: 'i',
+      length: 18,
+    }),
+    wait: Flags.duration({
+      summary: messages.getMessage('flags.wait.summary'),
+      char: 'w',
+      // TODO: check if other commands have the same default
+      defaultValue: 10,
+      unit: 'minutes',
+    }),
+  };
+
+  public async run(): Promise<DataImportResumeResult> {
+    const { flags } = await this.parse(DataImportResume);
+
+    const cache = await BulkImportRequestCache.create();
+
+    const resumeOpts = await cache.resolveResumeOptionsFromCache(
+      flags['job-id'],
+      flags['use-most-recent'],
+      undefined,
+      undefined
+    );
+
+    const conn = resumeOpts.options.connection;
+
+    const ms = new MultiStageOutput<JobInfoV2>({
+      jsonEnabled: flags.json ?? false,
+      stages: ['Creating ingest job', 'Processing the job'],
+      title: 'Importing data',
+      stageSpecificBlock: [
+        {
+          stage: 'Processing the job',
+          label: 'Processed records',
+          type: 'dynamic-key-value',
+          get: (data): string | undefined => {
+            if (data?.numberRecordsProcessed) {
+              return data.numberRecordsProcessed.toString();
+            }
+          },
+        },
+        {
+          stage: 'Processing the job',
+          label: 'Successful records',
+          type: 'dynamic-key-value',
+          get: (data): string | undefined => {
+            const numberRecordsFailed = data?.numberRecordsFailed ?? 0;
+
+            if (data?.numberRecordsProcessed) {
+              return (data.numberRecordsProcessed - numberRecordsFailed).toString();
+            }
+          },
+        },
+        {
+          stage: 'Processing the job',
+          label: 'Failed records',
+          type: 'dynamic-key-value',
+          get: (data): string => (data?.numberRecordsFailed ?? 0).toString(),
+        },
+      ],
+      postStagesBlock: [
+        {
+          label: 'Status',
+          type: 'dynamic-key-value',
+          bold: true,
+          get: (data) => data?.state,
+        },
+        {
+          label: 'Job Id',
+          type: 'dynamic-key-value',
+          bold: true,
+          get: (data) =>
+            data?.id &&
+            terminalLink(
+              data.id,
+              `${
+                conn.getAuthInfoFields().instanceUrl as string
+              }/lightning/setup/AsyncApiJobStatus/page?address=${encodeURIComponent(`/${data.id}`)}`
+            ),
+        },
+      ],
+    });
+
+    ms.skipTo('Processing the job');
+
+    const job = conn.bulk2.job('ingest', {
+      id: resumeOpts.jobInfo.id,
+    });
+
+    job.on('inProgress', (res: JobInfoV2) => {
+      ms.goto('Processing the job', res);
+    });
+
+    try {
+      await job.poll(5000, flags.wait.milliseconds);
+
+      const jobInfo = await job.check();
+
+      // send last data update so job status/num. of records processed/failed represent the last update
+      ms.goto('Processing the job', jobInfo);
+
+      if (jobInfo.numberRecordsFailed) {
+        ms.stop('failed');
+        // TODO: replace this msg to point to `sf data bulk results` when it's added (W-12408034)
+        throw messages.createError('error.failedRecordDetails', [
+          jobInfo.numberRecordsFailed,
+          conn.getUsername(),
+          job.id,
+        ]);
+      }
+
+      ms.stop();
+
+      return {
+        jobId: jobInfo.id,
+        processedRecords: jobInfo.numberRecordsProcessed,
+        successfulRecords: jobInfo.numberRecordsProcessed - (jobInfo.numberRecordsFailed ?? 0),
+        failedRecords: jobInfo.numberRecordsFailed,
+      };
+    } catch (err) {
+      const jobInfo = await job.check();
+
+      // send last data update so job status/num. of records processed/failed represent the last update
+      ms.goto('Processing the job', jobInfo);
+
+      if (err instanceof Error && err.name === 'JobPollingTimeout') {
+        ms.stop('failed');
+        throw messages.createError('error.timeout', [flags.wait.minutes, job.id]);
+      }
+
+      if (jobInfo.state === 'Failed') {
+        ms.stop('failed');
+        throw messages.createError(
+          'error.jobFailed',
+          [jobInfo.errorMessage, conn.getUsername(), job.id],
+          [],
+          err as Error
+        );
+      }
+
+      if (jobInfo.state === 'Aborted') {
+        ms.stop('failed');
+        // TODO: replace this msg to point to `sf data bulk results` when it's added (W-12408034)
+        throw messages.createError('error.jobAborted', [conn.getUsername(), job.id], [], err as Error);
+      }
+
+      throw err;
+    }
+  }
+}

--- a/src/commands/data/import/resume.ts
+++ b/src/commands/data/import/resume.ts
@@ -51,12 +51,7 @@ export default class DataImportResume extends SfCommand<DataImportResumeResult> 
 
     const cache = await BulkImportRequestCache.create();
 
-    const resumeOpts = await cache.resolveResumeOptionsFromCache(
-      flags['job-id'],
-      flags['use-most-recent'],
-      undefined,
-      undefined
-    );
+    const resumeOpts = await cache.resolveResumeOptionsFromCache(flags['job-id'] ?? flags['use-most-recent']);
 
     const conn = resumeOpts.options.connection;
 

--- a/src/commands/data/import/resume.ts
+++ b/src/commands/data/import/resume.ts
@@ -62,7 +62,7 @@ export default class DataImportResume extends SfCommand<DataImportResumeResult> 
     const conn = resumeOpts.options.connection;
 
     const ms = new MultiStageOutput<JobInfoV2>({
-      jsonEnabled: flags.json ?? false,
+      jsonEnabled: this.jsonEnabled(),
       stages: ['Creating ingest job', 'Processing the job'],
       title: 'Importing data',
       stageSpecificBlock: [

--- a/src/commands/data/import/resume.ts
+++ b/src/commands/data/import/resume.ts
@@ -38,11 +38,10 @@ export default class DataImportResume extends SfCommand<DataImportResumeResult> 
       length: 18,
     }),
     wait: Flags.duration({
-      summary: messages.getMessage('flags.wait.summary'),
       char: 'w',
-      // TODO: check if other commands have the same default
-      defaultValue: 10,
       unit: 'minutes',
+      summary: messages.getMessage('flags.wait.summary'),
+      defaultValue: 5,
     }),
   };
 

--- a/src/commands/data/import/resume.ts
+++ b/src/commands/data/import/resume.ts
@@ -30,13 +30,14 @@ export default class DataImportResume extends SfCommand<DataImportResumeResult> 
   public static readonly flags = {
     'use-most-recent': Flags.boolean({
       summary: messages.getMessage('flags.use-most-recent.summary'),
-      exclusive: ['job-id'],
+      exactlyOne: ['job-id'],
     }),
     'job-id': Flags.salesforceId({
       summary: messages.getMessage('flags.job-id.summary'),
       char: 'i',
       length: 18,
-      exclusive: ['use-most-recent'],
+      startsWith: '750',
+      exactlyOne: ['use-most-recent'],
     }),
     wait: Flags.duration({
       char: 'w',

--- a/src/commands/data/import/resume.ts
+++ b/src/commands/data/import/resume.ts
@@ -143,7 +143,7 @@ export default class DataImportResume extends SfCommand<DataImportResumeResult> 
       ms.goto('Processing the job', jobInfo);
 
       if (jobInfo.numberRecordsFailed) {
-        ms.stop('failed');
+        ms.error();
         // TODO: replace this msg to point to `sf data bulk results` when it's added (W-12408034)
         throw messages.createError('error.failedRecordDetails', [
           jobInfo.numberRecordsFailed,
@@ -167,12 +167,12 @@ export default class DataImportResume extends SfCommand<DataImportResumeResult> 
       ms.goto('Processing the job', jobInfo);
 
       if (err instanceof Error && err.name === 'JobPollingTimeout') {
-        ms.stop('failed');
+        ms.error();
         throw messages.createError('error.timeout', [flags.wait.minutes, job.id]);
       }
 
       if (jobInfo.state === 'Failed') {
-        ms.stop('failed');
+        ms.error();
         throw messages.createError(
           'error.jobFailed',
           [jobInfo.errorMessage, conn.getUsername(), job.id],
@@ -182,7 +182,7 @@ export default class DataImportResume extends SfCommand<DataImportResumeResult> 
       }
 
       if (jobInfo.state === 'Aborted') {
-        ms.stop('failed');
+        ms.error();
         // TODO: replace this msg to point to `sf data bulk results` when it's added (W-12408034)
         throw messages.createError('error.jobAborted', [conn.getUsername(), job.id], [], err as Error);
       }

--- a/src/commands/data/import/resume.ts
+++ b/src/commands/data/import/resume.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, salesforce.com, inc.
+ * Copyright (c) 2024, salesforce.com, inc.
  * All rights reserved.
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
@@ -7,6 +7,7 @@
 
 import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
 import { Messages } from '@salesforce/core';
+import { ensureString } from '@salesforce/ts-types';
 import { BulkImportRequestCache } from '../../../bulkDataRequestCache.js';
 import { BulkImportStages } from '../../../ux/bulkImportStages.js';
 
@@ -62,7 +63,7 @@ export default class DataImportResume extends SfCommand<DataImportResumeResult> 
     const stages = new BulkImportStages({
       resume: true,
       title: 'Importing data',
-      baseUrl: 'hehe',
+      baseUrl: ensureString(conn.getAuthInfoFields().instanceUrl),
       jsonEnabled: this.jsonEnabled(),
     });
 

--- a/src/commands/data/import/resume.ts
+++ b/src/commands/data/import/resume.ts
@@ -91,7 +91,13 @@ export default class DataImportResume extends SfCommand<DataImportResumeResult> 
           stage: 'Processing the job',
           label: 'Failed records',
           type: 'dynamic-key-value',
-          get: (data): string => (data?.numberRecordsFailed ?? 0).toString(),
+          get: (data): string | undefined => {
+            const numberRecordsFailed = data?.numberRecordsFailed ?? 0;
+
+            if (data?.numberRecordsProcessed) {
+              return numberRecordsFailed.toString();
+            }
+          },
         },
       ],
       postStagesBlock: [

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,6 +124,13 @@ export type ResumeBulkExportOptions = {
   };
 };
 
+export type ResumeBulkImportOptions = {
+  options: {
+    connection: Connection;
+  };
+  jobInfo: { id: string };
+};
+
 export type BulkResultV2 = {
   jobInfo: JobInfoV2;
   records?: BulkRecordsV2;

--- a/src/ux/bulkImportStages.ts
+++ b/src/ux/bulkImportStages.ts
@@ -67,13 +67,13 @@ export class BulkImportStages {
           label: 'Status',
           type: 'dynamic-key-value',
           bold: true,
-          get: (data) => data?.state,
+          get: (data): string | undefined => data?.state,
         },
         {
           label: 'Job Id',
           type: 'dynamic-key-value',
           bold: true,
-          get: (data) =>
+          get: (data): string | undefined =>
             data?.id &&
             `${baseUrl}/lightning/setup/AsyncApiJobStatus/page?address=${encodeURIComponent(`/${data.id}`)}`,
         },

--- a/src/ux/bulkImportStages.ts
+++ b/src/ux/bulkImportStages.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2024, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { MultiStageOutput } from '@oclif/multi-stage-output';
+import { IngestJobV2, JobInfoV2 } from '@jsforce/jsforce-node/lib/api/bulk2.js';
+import { Schema } from '@jsforce/jsforce-node';
+
+type Options = {
+  resume: boolean;
+  title: string;
+  baseUrl: string;
+  jsonEnabled: boolean;
+};
+
+export class BulkImportStages {
+  private mso: MultiStageOutput<JobInfoV2>;
+  private resume: boolean;
+
+  public constructor({ resume, title, baseUrl, jsonEnabled }: Options) {
+    this.resume = resume;
+    this.mso = new MultiStageOutput<JobInfoV2>({
+      title,
+      jsonEnabled,
+      stages: ['Creating ingest job', 'Processing the job'],
+      stageSpecificBlock: [
+        {
+          stage: 'Processing the job',
+          label: 'Processed records',
+          type: 'dynamic-key-value',
+          get: (data): string | undefined => {
+            if (data?.numberRecordsProcessed) {
+              return data.numberRecordsProcessed.toString();
+            }
+          },
+        },
+        {
+          stage: 'Processing the job',
+          label: 'Successful records',
+          type: 'dynamic-key-value',
+          get: (data): string | undefined => {
+            const numberRecordsFailed = data?.numberRecordsFailed ?? 0;
+
+            if (data?.numberRecordsProcessed) {
+              return (data.numberRecordsProcessed - numberRecordsFailed).toString();
+            }
+          },
+        },
+        {
+          stage: 'Processing the job',
+          label: 'Failed records',
+          type: 'dynamic-key-value',
+          get: (data): string | undefined => {
+            const numberRecordsFailed = data?.numberRecordsFailed ?? 0;
+
+            if (data?.numberRecordsProcessed) {
+              return numberRecordsFailed.toString();
+            }
+          },
+        },
+      ],
+      postStagesBlock: [
+        {
+          label: 'Status',
+          type: 'dynamic-key-value',
+          bold: true,
+          get: (data) => data?.state,
+        },
+        {
+          label: 'Job Id',
+          type: 'dynamic-key-value',
+          bold: true,
+          get: (data) =>
+            data?.id &&
+            `${baseUrl}/lightning/setup/AsyncApiJobStatus/page?address=${encodeURIComponent(`/${data.id}`)}`,
+        },
+      ],
+    });
+  }
+
+  public start(): void {
+    if (this.resume) {
+      this.mso.skipTo('Processing the job');
+    } else {
+      this.mso.goto('Creating ingest job');
+    }
+  }
+
+  public processingJob(): void {
+    this.mso.goto('Processing the job');
+  }
+
+  public setupJobListeners(job: IngestJobV2<Schema>): void {
+    job.on('inProgress', (res: JobInfoV2) => {
+      this.mso.updateData(res);
+    });
+    job.on('error', () => {
+      this.mso.error();
+    });
+  }
+
+  public update(data: JobInfoV2): void {
+    this.mso.updateData(data);
+  }
+
+  public stop(): void {
+    this.mso.stop();
+  }
+
+  public error(): void {
+    this.mso.error();
+  }
+}

--- a/src/ux/bulkImportStages.ts
+++ b/src/ux/bulkImportStages.ts
@@ -104,9 +104,6 @@ export class BulkImportStages {
     job.on('inProgress', (res: JobInfoV2) => {
       this.mso.updateData(res);
     });
-    job.on('error', () => {
-      this.mso.error();
-    });
   }
 
   public update(data: JobInfoV2): void {

--- a/src/ux/bulkImportStages.ts
+++ b/src/ux/bulkImportStages.ts
@@ -8,6 +8,7 @@
 import { MultiStageOutput } from '@oclif/multi-stage-output';
 import { IngestJobV2, JobInfoV2 } from '@jsforce/jsforce-node/lib/api/bulk2.js';
 import { Schema } from '@jsforce/jsforce-node';
+import terminalLink from 'terminal-link';
 
 type Options = {
   resume: boolean;
@@ -75,7 +76,13 @@ export class BulkImportStages {
           bold: true,
           get: (data): string | undefined =>
             data?.id &&
-            `${baseUrl}/lightning/setup/AsyncApiJobStatus/page?address=${encodeURIComponent(`/${data.id}`)}`,
+            terminalLink(
+              data.id,
+              `${baseUrl}/lightning/setup/AsyncApiJobStatus/page?address=${encodeURIComponent(`/${data.id}`)}`,
+              {
+                fallback: (text, url) => `${text} (${url})`,
+              }
+            ),
         },
       ],
     });

--- a/test/commands/data/export/bulk.nut.ts
+++ b/test/commands/data/export/bulk.nut.ts
@@ -27,17 +27,10 @@ describe('data export bulk NUTs', () => {
       devhubAuthStrategy: 'AUTO',
     });
 
-    // TODO: make this use the new `data import bulk` command when its available (W-13656292)
-    execCmd(
-      `data:upsert:bulk --sobject Account --file ${path.join(
-        'data',
-        'bulkUpsertLarge.csv'
-      )} --external-id Id --json --wait 10`,
-      {
-        ensureExitCode: 0,
-        cli: 'sf',
-      }
-    );
+    execCmd(`data:import:bulk --sobject Account --file ${path.join('data', 'bulkUpsertLarge.csv')} --json --wait 10`, {
+      ensureExitCode: 0,
+      cli: 'sf',
+    });
 
     totalAccountRecords = execCmd<{ totalSize: number }>('data query -q "select count() from account" --json', {
       ensureExitCode: 0,

--- a/test/commands/data/export/bulk.nut.ts
+++ b/test/commands/data/export/bulk.nut.ts
@@ -29,7 +29,6 @@ describe('data export bulk NUTs', () => {
 
     execCmd(`data:import:bulk --sobject Account --file ${path.join('data', 'bulkUpsertLarge.csv')} --json --wait 10`, {
       ensureExitCode: 0,
-      cli: 'sf',
     });
 
     totalAccountRecords = execCmd<{ totalSize: number }>('data query -q "select count() from account" --json', {

--- a/test/commands/data/export/resume.nut.ts
+++ b/test/commands/data/export/resume.nut.ts
@@ -30,7 +30,6 @@ describe('data export resume NUTs', () => {
 
     execCmd(`data:import:bulk --sobject Account --file ${path.join('data', 'bulkUpsertLarge.csv')} --json --wait 10`, {
       ensureExitCode: 0,
-      cli: 'sf',
     });
 
     totalAccountRecords = execCmd<{ totalSize: number }>('data query -q "select count() from account" --json', {

--- a/test/commands/data/export/resume.nut.ts
+++ b/test/commands/data/export/resume.nut.ts
@@ -28,17 +28,10 @@ describe('data export resume NUTs', () => {
       devhubAuthStrategy: 'AUTO',
     });
 
-    // TODO: make this use the new `data import bulk` command when its available (W-13656292)
-    execCmd(
-      `data:upsert:bulk --sobject Account --file ${path.join(
-        'data',
-        'bulkUpsertLarge.csv'
-      )} --external-id Id --json --wait 10`,
-      {
-        ensureExitCode: 0,
-        cli: 'sf',
-      }
-    );
+    execCmd(`data:import:bulk --sobject Account --file ${path.join('data', 'bulkUpsertLarge.csv')} --json --wait 10`, {
+      ensureExitCode: 0,
+      cli: 'sf',
+    });
 
     totalAccountRecords = execCmd<{ totalSize: number }>('data query -q "select count() from account" --json', {
       ensureExitCode: 0,

--- a/test/commands/data/import/bulk.nut.ts
+++ b/test/commands/data/import/bulk.nut.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import path from 'node:path';
+import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
+import { expect } from 'chai';
+import { DataImportBulkResult } from '../../../../src/commands/data/import/bulk.js';
+
+describe('data import bulk NUTs', () => {
+  let session: TestSession;
+
+  before(async () => {
+    session = await TestSession.create({
+      scratchOrgs: [
+        {
+          config: 'config/project-scratch-def.json',
+          setDefault: true,
+        },
+      ],
+      project: { sourceDir: path.join('test', 'test-files', 'data-project') },
+      devhubAuthStrategy: 'AUTO',
+    });
+  });
+
+  after(async () => {
+    await session?.clean();
+  });
+
+  it('should import account records', () => {
+    const result = execCmd<DataImportBulkResult>(
+      `data import bulk --file ${path.join('data', 'bulkUpsertLarge.csv')} --sobject Account --wait 10 --json`,
+      { ensureExitCode: 0 }
+    ).jsonOutput?.result as DataImportBulkResult;
+
+    expect(result.jobId).not.be.undefined;
+    expect(result.jobId.length).to.equal(18);
+    expect(result.processedRecords).to.equal(76_380);
+    expect(result.successfulRecords).to.equal(76_380);
+    expect(result.failedRecords).to.equal(0);
+  });
+});

--- a/test/commands/data/import/bulk.nut.ts
+++ b/test/commands/data/import/bulk.nut.ts
@@ -5,7 +5,6 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import path from 'node:path';
-import { platform } from 'node:os';
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
 import { DataImportBulkResult } from '../../../../src/commands/data/import/bulk.js';
@@ -49,11 +48,9 @@ describe('data import bulk NUTs', () => {
   it('should report error msg from a failed job', async () => {
     const csvFile = await generateAccountsCsv(session.dir);
 
-    // we pass the wrong line ending on purpose to make the job fail.
-    const wrongLineEnding = platform() === 'win32' ? 'LF' : 'CRLF';
-
+    // we pass `Contact` instead of `Account` on purpose to make the job fail
     const result = execCmd<DataImportBulkResult>(
-      `data import bulk --file ${csvFile} --sobject Account --wait 10 --json --line-ending ${wrongLineEnding}`,
+      `data import bulk --file ${csvFile} --sobject Contact --wait 10 --json`,
       { ensureExitCode: 1 }
     ).jsonOutput;
 

--- a/test/commands/data/import/resume.nut.ts
+++ b/test/commands/data/import/resume.nut.ts
@@ -31,7 +31,7 @@ describe('data import resume NUTs', () => {
     await session?.clean();
   });
 
-  it('should resume bulk import', async () => {
+  it('should resume bulk import via --job-id', async () => {
     const csvFile = await generateAccountsCsv(session.dir);
 
     // about the type assertion at the end:
@@ -54,10 +54,8 @@ describe('data import resume NUTs', () => {
     expect(importResumeResult.failedRecords).to.equal(0);
   });
 
-  it('should resume bulk import, --use-most-recent', async () => {
+  it('should resume bulk import via--use-most-recent', async () => {
     const csvFile = await generateAccountsCsv(session.dir);
-    // eslint-disable-next-line no-console
-    console.log(`csvFile: ${csvFile}`);
 
     const command = `data import bulk --file ${csvFile} --sobject account --async --json`;
 
@@ -90,7 +88,7 @@ describe('data import resume NUTs', () => {
  *
  * Each `Account.name` field has a unique timestamp for idempotent runs.
  */
-async function generateAccountsCsv(savePath: string): Promise<string> {
+export async function generateAccountsCsv(savePath: string): Promise<string> {
   const id = Date.now();
 
   let csv = 'NAME,TYPE,PHONE,WEBSITE' + EOL;

--- a/test/commands/data/import/resume.nut.ts
+++ b/test/commands/data/import/resume.nut.ts
@@ -95,7 +95,7 @@ async function generateAccountsCsv(savePath: string): Promise<string> {
 
   let csv = 'NAME,TYPE,PHONE,WEBSITE' + EOL;
 
-  for (let i = 0; i <= 10_000; i++) {
+  for (let i = 1; i <= 10_000; i++) {
     csv += `account ${id} #${i},Account,415-555-0000,http://www.accountImport${i}.com${EOL}`;
   }
 

--- a/test/commands/data/import/resume.nut.ts
+++ b/test/commands/data/import/resume.nut.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2024, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import path from 'node:path';
+import { writeFile } from 'node:fs/promises';
+import { EOL } from 'node:os';
+import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
+import { expect } from 'chai';
+import { DataImportBulkResult } from '../../../../src/commands/data/import/bulk.js';
+
+describe('data import resume NUTs', () => {
+  let session: TestSession;
+
+  before(async () => {
+    session = await TestSession.create({
+      scratchOrgs: [
+        {
+          config: 'config/project-scratch-def.json',
+          setDefault: true,
+        },
+      ],
+      project: { sourceDir: path.join('test', 'test-files', 'data-project') },
+      devhubAuthStrategy: 'AUTO',
+    });
+  });
+
+  after(async () => {
+    await session?.clean();
+  });
+
+  it('should resume bulk import', async () => {
+    const csvFile = await generateAccountsCsv(session.dir);
+
+    // about the type assertion at the end:
+    // I'm passing `--json` in and `ensureExitCode: 0` so I should always have a JSON result.
+    const exportAsyncResult = execCmd<DataImportBulkResult>(
+      `data import bulk --file ${csvFile} --sobject account --async --json`,
+      { ensureExitCode: 0 }
+    ).jsonOutput?.result as DataImportBulkResult;
+
+    expect(exportAsyncResult.jobId).not.to.be.undefined;
+    expect(exportAsyncResult.jobId).to.be.length(18);
+
+    const importResumeResult = execCmd<DataImportBulkResult>(
+      `data import resume -i ${exportAsyncResult.jobId} --json`,
+      { ensureExitCode: 0 }
+    ).jsonOutput?.result as DataImportBulkResult;
+
+    expect(importResumeResult.processedRecords).to.equal(10_000);
+    expect(importResumeResult.successfulRecords).to.equal(10_000);
+    expect(importResumeResult.failedRecords).to.equal(0);
+  });
+
+  it('should resume bulk import, --use-most-recent', async () => {
+    const csvFile = await generateAccountsCsv(session.dir);
+    // eslint-disable-next-line no-console
+    console.log(`csvFile: ${csvFile}`);
+
+    const command = `data import bulk --file ${csvFile} --sobject account --async --json`;
+
+    // about the type assertion at the end:
+    // I'm passing `--json` in and `ensureExitCode: 0` so I should always have a JSON result.
+    const exportAsyncResult = execCmd<DataImportBulkResult>(command, { ensureExitCode: 0 }).jsonOutput
+      ?.result as DataImportBulkResult;
+
+    expect(exportAsyncResult.jobId).not.to.be.undefined;
+    expect(exportAsyncResult.jobId).to.be.length(18);
+
+    const importResumeResult = execCmd<DataImportBulkResult>('data import resume --use-most-recent --json', {
+      ensureExitCode: 0,
+    }).jsonOutput?.result as DataImportBulkResult;
+
+    expect(importResumeResult.jobId).not.to.be.undefined;
+    expect(importResumeResult.jobId).to.be.length(18);
+
+    // validate the cache is returning the job ID from the last async import
+    expect(importResumeResult.jobId).to.equal(exportAsyncResult.jobId);
+
+    expect(importResumeResult.processedRecords).to.equal(10_000);
+    expect(importResumeResult.successfulRecords).to.equal(10_000);
+    expect(importResumeResult.failedRecords).to.equal(0);
+  });
+});
+
+/**
+ * Generates a CSV file with 10_000 account records to insert
+ *
+ * Each `Account.name` field has a unique timestamp for idempotent runs.
+ */
+async function generateAccountsCsv(savePath: string): Promise<string> {
+  const id = Date.now();
+
+  let csv = 'NAME,TYPE,PHONE,WEBSITE' + EOL;
+
+  for (let i = 0; i <= 10_000; i++) {
+    csv += `account ${id} #${i},Account,415-555-0000,http://www.accountImport${i}.com${EOL}`;
+  }
+
+  const accountsCsv = path.join(savePath, 'bulkImportAccounts1.csv');
+
+  await writeFile(accountsCsv, csv);
+
+  return accountsCsv;
+}


### PR DESCRIPTION
### What does this PR do?
Adds 2 new commands:

## `data import bulk`
take a CSV with fields of an object and bulk insert them into the org:

#### happy path
https://github.com/user-attachments/assets/aaf214c5-c36b-46e3-aee9-44cbebc4edeb


#### failed to import all records

https://github.com/user-attachments/assets/a8699832-e161-4873-bddc-cc6fd9456bd5

#### job failure
![Screenshot 2024-10-16 at 11 08 37 AM](https://github.com/user-attachments/assets/0e70777f-ab1c-47f1-9dea-ed64c32c8aac)

#### job aborted
https://github.com/user-attachments/assets/a099d732-6a40-41f3-830e-76af786dfe11

## `data import resume`
resume an async/timed out import

https://github.com/user-attachments/assets/b05e4849-abb9-4d15-9ee0-983444132f35

### testing instructions

checkout PR locally and `sf plugins link` it, you can use the following CSV files available in plugin-data for testing:
`test/test-files/data-project/data/bulkUpsertLarge.csv` (big)
`test/test-files/data-project/data/bulkUpsert.csv` (smol)

### What issues does this PR fix or reference?
@W-13656292@