### PR TITLE
fix: add ability to import RecordTypeId when RecordType.Name is present

### DIFF
--- a/messages/importApi.md
+++ b/messages/importApi.md
@@ -84,4 +84,4 @@ The file %s includes references (ex: '@AccountRef1'). Those are only supported w
 
 # error.noRecordTypeName
 
-This file contains an unresolvable RecordType ID, try exporting data with RecordType.Name in the query
+This file contains an unresolvable RecordType ID. Try exporting the data by specifying RecordType.Name in the SOQL query, and then run the data import again.

--- a/messages/importApi.md
+++ b/messages/importApi.md
@@ -81,3 +81,7 @@ There are references in a data file %s that can't be resolved:
 # error.RefsInFiles
 
 The file %s includes references (ex: '@AccountRef1'). Those are only supported with --plan, not --files.`
+
+# error.noRecordTypeName
+
+This file contains an unresolvable RecordType ID, try exporting data with RecordType.Name in the query

--- a/src/api/data/tree/importCommon.ts
+++ b/src/api/data/tree/importCommon.ts
@@ -31,25 +31,6 @@ export const transformRecordTypeEntries = async (
   conn: Connection,
   records: SObjectTreeInput[]
 ): Promise<SObjectTreeInput[]> => {
-  /*
-this was my attempt to fix relationship lookups in the export query field for the generic case, it eventually failed due to the soql query
-having hardcoded fields to lookup. RecordTypes have  an SobjectType field, but not every relationship will
-TODO: figure out a generic way to import records queried like
-"SELECT RecordType.Name, Account.Name FROM Asset"
- */
-  // for (const entry of Object.values(partWithRefsReplaced.records)) {
-  //   for (const [subType, value] of Object.entries(entry)) {
-  //     if ((value as { attributes: { type: string }; Name: string }).attributes) {
-  //       const info = value as { attributes: { type: string }; Name: string };
-  //       // eslint-disable-next-line no-await-in-loop
-  //       const newid = await conn.singleRecordQuery<{ Id: string }>(
-  //         `SELECT Id FROM ${info.attributes.type} WHERE Name = '${info.Name}' AND SobjectType='${entry.attributes.type}'`
-  //       );
-  //       delete entry[subType];
-  //       entry[`${subType}Id`] = newid.Id;
-  //     }
-  //   }
-  // }
   await Promise.all(
     records.map(async (record) => {
       const recordName = getString(record, 'RecordType.Name');

--- a/src/api/data/tree/importCommon.ts
+++ b/src/api/data/tree/importCommon.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { Connection, SfError, Messages } from '@salesforce/core';
-import { getString } from '@salesforce/ts-types';
+import { getObject, getString } from '@salesforce/ts-types';
 import type { SObjectTreeInput, SObjectTreeFileContents } from '../../../types.js';
 import type { ResponseRefs, TreeResponse } from './importTypes.js';
 
@@ -61,7 +61,7 @@ TODO: figure out a generic way to import records queried like
         ).Id;
         delete record['RecordType'];
         record['RecordTypeId'] = targetRecordTypeId;
-      } else {
+      } else if (getObject(record, 'RecordType') && !recordName) {
         throw messages.createError('error.noRecordTypeName');
       }
     })

--- a/src/api/data/tree/importPlan.ts
+++ b/src/api/data/tree/importPlan.ts
@@ -18,6 +18,7 @@ import {
   getResultsIfNoError,
   parseDataFileContents,
   sendSObjectTreeRequest,
+  transformRecordTypeEntries,
   treeSaveErrorHandler,
 } from './importCommon.js';
 import { isUnresolvedRef } from './functions.js';
@@ -109,6 +110,7 @@ const getResults =
       `Sending ${partWithRefsReplaced.filePath} (${partWithRefsReplaced.records.length} records for ${partWithRefsReplaced.sobject}) to the API`
     );
     try {
+      partWithRefsReplaced.records = await transformRecordTypeEntries(conn, partWithRefsReplaced.records);
       const contents = JSON.stringify({ records: partWithRefsReplaced.records });
       const newResults = getResultsIfNoError(partWithRefsReplaced.filePath)(
         await sendSObjectTreeRequest(conn)(partWithRefsReplaced.sobject)(contents)

--- a/test/api/data/tree/importApi.test.ts
+++ b/test/api/data/tree/importApi.test.ts
@@ -645,7 +645,7 @@ describe('ImportApi', () => {
         await transformRecordTypeEntries(Connection.prototype, travelExpenseJson.records);
       } catch (e) {
         expect((e as Error).message).to.equal(
-          'This file contains an unresolvable RecordType ID, try exporting data with RecordType.Name in the query'
+          'This file contains an unresolvable RecordType ID. Try exporting the data by specifying RecordType.Name in the SOQL query, and then run the data import again.'
         );
       }
     });

--- a/test/api/data/tree/importApi.test.ts
+++ b/test/api/data/tree/importApi.test.ts
@@ -31,28 +31,12 @@ const accountsContactsPlanJSON = JSON.parse(
 );
 const dataImportPlanSchema = JSON.parse(fs.readFileSync('schema/dataImportPlanSchema.json', 'utf-8'));
 
-// Sample response data
-// const sampleResponseData = [
-//   { referenceId: 'SampleAccountRef', id: '001xx000003DKpJAAW' },
-//   { referenceId: 'SampleAcct2Ref', id: '001xx000003DKpKAAW' },
-//   { referenceId: 'PresidentSmithRef', id: '003xx000004TtqCAAS' },
-//   { referenceId: 'VPEvansRef', id: '003xx000004TtqIAAS' }
-// ];
-
 const sampleSObjectTypes = {
   SampleAccountRef: 'Account',
   SampleAcct2Ref: 'Account',
   PresidentSmithRef: 'Contact',
   VPEvansRef: 'Contact',
 };
-
-// Sample command display data
-// const sampleDisplayData = [
-//   { refId: 'SampleAccountRef', type: 'Account', id: '001xx000003DKpJAAW' },
-//   { refId: 'SampleAcct2Ref', type: 'Account', id: '001xx000003DKpKAAW' },
-//   { refId: 'PresidentSmithRef', type: 'Contact', id: '003xx000004TtqCAAS' },
-//   { refId: 'VPEvansRef', type: 'Contact', id: '003xx000004TtqIAAS' }
-// ];
 
 const jsonRefRegex = /[.]*["|'][A-Z0-9_]*["|'][ ]*:[ ]*["|']@([A-Z0-9_]*)["|'][.]*/gim;
 
@@ -680,134 +664,3 @@ describe('ImportApi', () => {
     });
   });
 });
-
-/**
- * Use these as the basis for integration tests.
- */
-// describe('data:import', () => {
-//   let force;
-//   let org;
-
-//   before(() => {
-//     workspace = new TestWorkspace();
-//     org = new Org();
-//     force = org.force;
-
-//     sandbox.stub(force, 'describeData').callsFake(() => Promise.resolve());
-
-//     // copy data files to workspace
-//     fse.copySync(path.join(dir, 'data'), path.join(workspace.getWorkspacePath(), 'data'));
-
-//     // Some test require a scratch org config in the workspace
-//     return workspace
-//       .configureHubOrg()
-//       .then(() => org.saveConfig(orgConfig))
-//       .then(() => workspace.configureWorkspaceScratchOrg());
-//   });
-
-//   after(() => {
-//     workspace.clean();
-//   });
-
-//   afterEach(() => {
-//     sandbox.restore();
-//   });
-
-//   describe('DataTreeImportCommand run()', () => {
-//     it('should output the plan schema when confighelp flag specified', async () => {
-//       const context = {
-//         flags: {
-//           confighelp: true,
-//           json: true
-//         },
-//         org: new Org()
-//       };
-//       const dataTreeImportCommand = new DataTreeImportCommand([], null);
-//       set(dataTreeImportCommand, 'ux', { log: sandbox.spy() });
-//       sandbox.stub(dataTreeImportCommand as any, 'resolveLegacyContext').callsFake(() => Promise.resolve(context));
-
-//       const outputJson = await dataTreeImportCommand.run();
-//       expect(outputJson).to.deep.equal(dataImportPlanSchema);
-//     });
-//   });
-
-//   // Test importing a single data file
-//   describe('#File', () => {
-//     beforeEach(() => {
-//       sandbox.stub(force, 'request').callsFake(() =>
-//         Promise.resolve({
-//           hasErrors: false,
-//           results: sampleResponseData
-//         })
-//       );
-//     });
-
-//     it('API: Should insert Accounts and child Contacts', () => {
-//       const dataImportCmd = new DataImportApi(org);
-//       const config = {
-//         json: true,
-//         username,
-//         sobjecttreefiles: './data/accounts-contacts-tree.json'
-//       };
-
-//       return dataImportCmd.execute(config).then(result => {
-//         expect(result).to.eql(sampleDisplayData);
-//       });
-//     });
-//   });
-
-//   // test importing via plan
-//   describe('#Plan', () => {
-//     const contactsOnly1 = [
-//       { referenceId: 'FrontDeskRef', id: '003xx000004TtqwAAC' },
-//       { referenceId: 'ManagerRef', id: '003xx000004TtqxAAC' }
-//     ];
-//     const contactsOnly2 = [
-//       { referenceId: 'JanitorRef', id: '003xx000004Ttr1AAC' },
-//       { referenceId: 'DeveloperRef', id: '003xx000004Ttr2AAC' }
-//     ];
-
-//     const sampleDisplayContacts1 = [
-//       { refId: 'FrontDeskRef', type: 'Contact', id: '003xx000004TtqwAAC' },
-//       { refId: 'ManagerRef', type: 'Contact', id: '003xx000004TtqxAAC' }
-//     ];
-
-//     const sampleDisplayContacts2 = [
-//       { refId: 'JanitorRef', type: 'Contact', id: '003xx000004Ttr1AAC' },
-//       { refId: 'DeveloperRef', type: 'Contact', id: '003xx000004Ttr2AAC' }
-//     ];
-
-//     let requestStub;
-
-//     beforeEach(() => {
-//       requestStub = sandbox.stub(force, 'request');
-//       requestStub.onCall(0).returns(Promise.resolve({ hasErrors: false, results: sampleResponseData }));
-//       requestStub.onCall(1).returns(Promise.resolve({ hasErrors: false, results: contactsOnly1 }));
-//       requestStub.onCall(2).returns(Promise.resolve({ hasErrors: false, results: contactsOnly2 }));
-//     });
-
-//     it('API: Should insert Accounts and child Contacts', () => {
-//       const dataImportCmd = new DataImportApi(org);
-//       const config = {
-//         json: true,
-//         username,
-//         plan: './data/accounts-contacts-plan.json',
-//         importPlanConfig: accountsContactsPlanJSON
-//       };
-//       const expected = [...sampleDisplayData, ...sampleDisplayContacts1, ...sampleDisplayContacts2];
-
-//       return dataImportCmd.execute(config).then(result => {
-//         expect(result).to.eql(expected);
-//       });
-//     });
-//   });
-
-//   describe('DataImportConfigHelpCommand', () => {
-//     it('should return the schema', () => {
-//       const dataImportConfigHelpCommand = new DataImportConfigHelpCommand();
-//       return dataImportConfigHelpCommand.execute({ org }).then(result => {
-//         expect(result).to.deep.equal(dataImportPlanSchema);
-//       });
-//     });
-//   });
-// });

--- a/test/api/data/tree/test-files/travel-expense.json
+++ b/test/api/data/tree/test-files/travel-expense.json
@@ -1,0 +1,46 @@
+{
+  "records": [
+    {
+      "attributes": {
+        "type": "Travel_Expense__c",
+        "referenceId": "Travel_Expense__cRef1"
+      },
+      "RecordType": {
+        "attributes": {
+          "type": "RecordType",
+          "url": "/services/data/v62.0/sobjects/RecordType/012D6000004PyzjIAC"
+        },
+        "Name": "food"
+      },
+      "Name": "lunch"
+    },
+    {
+      "attributes": {
+        "type": "Travel_Expense__c",
+        "referenceId": "Travel_Expense__cRef2"
+      },
+      "RecordType": {
+        "attributes": {
+          "type": "RecordType",
+          "url": "/services/data/v62.0/sobjects/RecordType/012D6000004PyztIAC"
+        },
+        "Name": "flights"
+      },
+      "Name": "BOI-STX"
+    },
+    {
+      "attributes": {
+        "type": "Travel_Expense__c",
+        "referenceId": "Travel_Expense__cRef3"
+      },
+      "RecordType": {
+        "attributes": {
+          "type": "RecordType",
+          "url": "/services/data/v62.0/sobjects/RecordType/012D6000004PyzjIAC"
+        },
+        "Name": "food"
+      },
+      "Name": "dinner"
+    }
+  ]
+}


### PR DESCRIPTION
### What does this PR do?
if you export with a similar command `data tree export --query "SELECT RecordType.Name, Name FROM Account`  
`data:tree:import` can now resolve the `RecordType` sub-reference correctly

NUTs weren't possible due to a manual step in the target org 😦 

### What issues does this PR fix or reference?
@W-4472514@