### PR TITLE
fix(data:query): deprecate bulk mode

### DIFF
--- a/src/commands/data/query.ts
+++ b/src/commands/data/query.ts
@@ -104,14 +104,10 @@ export class DataSoqlQueryCommand extends SfCommand<unknown> {
     this.logger = await Logger.child('data:soql:query');
     const flags = (await this.parse(DataSoqlQueryCommand)).flags;
 
-    if (flags.bulk === false && flags.wait) {
-      this.warn(`Using \`--wait\` without \`--bulk\` is deprecated and will be removed after January 1, 2025.
-You can safely remove \`--wait\` (it never had any effect on the command without \`--bulk\`).
-`);
-    }
-    if (flags.bulk === false && flags.async) {
-      this.warn(`Using \`--async\` without \`--bulk\` is deprecated and will be removed after January 1, 2025.
-You can safely remove \`--async\` (it never had any effect on the command without \`--bulk\`).
+    if (flags.bulk || flags.wait || flags.async) {
+      this
+        .warn(`Bulk mode for "data query" is deprecated, the following flags will be removed after March 2025: --bulk | --wait | --async.
+Use "data export bulk" for bulk queries instead.
 `);
     }
 

--- a/src/commands/data/query.ts
+++ b/src/commands/data/query.ts
@@ -129,7 +129,7 @@ export class DataSoqlQueryCommand extends SfCommand<DataQueryResult> {
 
     if (flags.bulk || flags.wait || flags.async) {
       this
-        .warn(`Bulk mode for "data query" is deprecated, the following flags will be removed after March 2025: --bulk | --wait | --async.
+        .warn(`Bulk mode for "data query" is deprecated, the following flags will be removed after April 2025: --bulk | --wait | --async.
 Use "data export bulk" for bulk queries instead.
 `);
     }

--- a/src/commands/data/query/resume.ts
+++ b/src/commands/data/query/resume.ts
@@ -29,6 +29,12 @@ export class BulkQueryReport extends SfCommand<unknown> {
   public static readonly examples = reportMessages.getMessages('examples');
   public static readonly aliases = ['force:data:soql:bulk:report'];
   public static readonly deprecateAliases = true;
+  public static state = 'deprecated';
+  public static readonly deprecationOptions = {
+    message: `Bulk mode for "data query" is deprecated, this command will be removed after March 2025.
+Use "data export bulk | data export resume" for bulk queries instead.
+`,
+  };
 
   public static readonly flags = {
     'target-org': { ...optionalOrgFlagWithDeprecations },

--- a/src/commands/data/query/resume.ts
+++ b/src/commands/data/query/resume.ts
@@ -31,7 +31,7 @@ export class BulkQueryReport extends SfCommand<unknown> {
   public static readonly deprecateAliases = true;
   public static state = 'deprecated';
   public static readonly deprecationOptions = {
-    message: `Bulk mode for "data query" is deprecated, this command will be removed after March 2025.
+    message: `Bulk mode for "data query" is deprecated, this command will be removed after April 2025.
 Use "data export bulk | data export resume" for bulk queries instead.
 `,
   };


### PR DESCRIPTION
### What does this PR do?
Deprecates bulk mode for `data query`, that includes:
* data query flags: `--bulk`, --wait` and `--async`
* `data query resume` command (it only resumes `data query --bulk` operations.

Last bits of the `Enhance and Expand CLI "Bulk Query" Operations` epic, `data export bulk` is better suited to handle million of records.

### What issues does this PR fix or reference?
@W-17396706@