### PR TITLE
feat(data:query): add `--output-file` flag

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -213,6 +213,7 @@
       "flags-dir",
       "json",
       "loglevel",
+      "output-file",
       "perflog",
       "query",
       "result-format",

--- a/messages/reporter.md
+++ b/messages/reporter.md
@@ -1,3 +1,0 @@
-# bulkV2Result
-
-Job %s | Status %s | Records processed %d | Records failed %d

--- a/messages/soql.query.md
+++ b/messages/soql.query.md
@@ -58,7 +58,7 @@ Time to wait for the command to finish, in minutes.
 
 # flags.output-file.summary
 
-File where records are written.
+File where records are written; only CSV and JSON output formats are supported. 
 
 # displayQueryRecordsRetrieved
 

--- a/messages/soql.query.md
+++ b/messages/soql.query.md
@@ -16,9 +16,9 @@ When using --bulk, the command waits 3 minutes by default for the query to compl
 
   <%= config.bin %> <%= command.id %> --query "SELECT Id, Name, Account.Name FROM Contact"
 
-- Read the SOQL query from a file called "query.txt"; the command uses the org with alias "my-scratch":
+- Read the SOQL query from a file called "query.txt" and write the CSV-formatted output to a file; the command uses the org with alias "my-scratch":
 
-  <%= config.bin %> <%= command.id %> --file query.txt --target-org my-scratch
+  <%= config.bin %> <%= command.id %> --file query.txt --output-file output.csv --result-format csv --target-org my-scratch
 
 - Use Tooling API to run a query on the ApexTrigger Tooling API object:
 
@@ -58,7 +58,7 @@ Time to wait for the command to finish, in minutes.
 
 # flags.output-file.summary
 
-File where records are written; only CSV and JSON output formats are supported. 
+File where records are written; only CSV and JSON output formats are supported.
 
 # displayQueryRecordsRetrieved
 

--- a/messages/soql.query.md
+++ b/messages/soql.query.md
@@ -56,6 +56,10 @@ Include deleted records. By default, deleted records are not returned.
 
 Time to wait for the command to finish, in minutes.
 
+# flags.output-file.summary
+
+File where records are written.
+
 # displayQueryRecordsRetrieved
 
 Total number of records retrieved: %s.

--- a/src/queryUtils.ts
+++ b/src/queryUtils.ts
@@ -10,17 +10,17 @@ import { FormatTypes, JsonReporter } from './reporters/query/reporters.js';
 import { CsvReporter } from './reporters/query/csvReporter.js';
 import { HumanReporter } from './reporters/query/humanReporter.js';
 
-export const displayResults = (queryResult: SoqlQueryResult, resultFormat: FormatTypes): void => {
+export const displayResults = (queryResult: SoqlQueryResult, resultFormat: FormatTypes, outputFile?: string): void => {
   let reporter: HumanReporter | JsonReporter | CsvReporter;
   switch (resultFormat) {
     case 'human':
       reporter = new HumanReporter(queryResult, queryResult.columns);
       break;
     case 'json':
-      reporter = new JsonReporter(queryResult, queryResult.columns);
+      reporter = new JsonReporter(queryResult, queryResult.columns, outputFile);
       break;
     case 'csv':
-      reporter = new CsvReporter(queryResult, queryResult.columns);
+      reporter = new CsvReporter(queryResult, queryResult.columns, outputFile);
       break;
   }
   // delegate to selected reporter


### PR DESCRIPTION
### What does this PR do?

Adds `--output-file` flag to `data query` command.

`data query` has 3 output formats (`csv`, `json` or `human`, can be set via `--result-format`), the new `--output-file` will only work with `csv` and `json` format b/c:
1. those 2 formats are consumable by other tools
2. `human` format uses oclif/table which can't make it write output to a file instead of stdout without some additional work.

expected behavior:
* no `--output-file` -> records printed to stdout
* `--output-file` and `--result-format` csv or json -> records saved to file
* `--output-file` and `--result-format` csv or json and `--json` -> records saved to file, json output includes file path
* `--output-file` and `--result-format human` -> error

See https://salesforce.quip.com/QuS1ABld0leA

### What issues does this PR fix or reference?
@W-17336452@