### PR TITLE
fix(data:export): properly handle big JSON exports

### DIFF
--- a/src/bulkUtils.ts
+++ b/src/bulkUtils.ts
@@ -128,9 +128,9 @@ export async function exportRecords(
 
     if (outputInfo.format === 'json') {
       const jsonWritable = fs.createWriteStream(outputInfo.filePath, {
-        // Open file for reading and appending. The file is created if it does not exist but fails if the path exists.
+        // Open file for appending. The file is created if it does not exist.
         // https://nodejs.org/api/fs.html#file-system-flags
-        flags: 'ax+',
+        flags: 'a', // append mode
       });
 
       const totalRecords = jobInfo.numberRecordsProcessed;
@@ -166,6 +166,8 @@ export async function exportRecords(
           ? [
               Readable.from(res.body.slice(res.body.indexOf(EOL) + 1)),
               fs.createWriteStream(outputInfo.filePath, {
+                // Open file for appending. The file is created if it does not exist.
+                // https://nodejs.org/api/fs.html#file-system-flags
                 flags: 'a', // append mode
               }),
             ]


### PR DESCRIPTION
### What does this PR do?
Updates bulk export utility to ensure it doesn't check if the JSON file where records will be written already exists.
For a few thousands of records, the API will still return all in one batch so NUTs were passing but if the job splits results in +1 batch then `data export bulk --result-format json` fails when trying to save the second batch because the FS flag instructs node to fail if the file already exists (which does, from the 1st batch that was saved).

repro:
query `ScratchOrgInfo` records in our na40 hub, there are ~1.6M records that get split in ~8 batches:

```
sf data export bulk -q 'select id,ExpirationDate from scratchorginfo' --result-format json --target-org na40 --output-file data.json --wait 20
```

you should get `Error (EEXIST): EEXIST: file already exists, open 'data.json'`. With this fix you should get a valid json, check its length with `jq length data.json`.

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/3138
@W-17380350@