### PR TITLE
fix(bulk): fallback `columnDelimtier` to `COMMA`

### DIFF
--- a/src/bulkUtils.ts
+++ b/src/bulkUtils.ts
@@ -243,7 +243,8 @@ export async function detectDelimiter(filePath: string): Promise<ColumnDelimiter
     }
   }
 
-  const columDelimiter = delimiterMap.get(detectedDelimiter ?? '');
+  // default to `COMMA` if no delimiter was found in the CSV file (1 column)
+  const columDelimiter = delimiterMap.get(detectedDelimiter ?? ',');
 
   if (columDelimiter === undefined) {
     throw new SfError(`Failed to detect column delimiter used in ${filePath}.`);

--- a/test/bulkUtils.test.ts
+++ b/test/bulkUtils.test.ts
@@ -15,6 +15,7 @@ describe('bulkUtils', () => {
       expect(await detectDelimiter('./test/test-files/csv/backquote.csv')).to.equal('BACKQUOTE');
       expect(await detectDelimiter('./test/test-files/csv/caret.csv')).to.equal('CARET');
       expect(await detectDelimiter('./test/test-files/csv/comma.csv')).to.equal('COMMA');
+      expect(await detectDelimiter('./test/test-files/csv/single-column.csv')).to.equal('COMMA');
       expect(await detectDelimiter('./test/test-files/csv/comma_wrapped_values.csv')).to.equal('COMMA');
       expect(await detectDelimiter('./test/test-files/csv/pipe.csv')).to.equal('PIPE');
       expect(await detectDelimiter('./test/test-files/csv/semicolon.csv')).to.equal('SEMICOLON');

--- a/test/test-files/csv/single-column.csv
+++ b/test/test-files/csv/single-column.csv
@@ -1,0 +1,11 @@
+NAME
+account Upsert #0
+account Upsert #1
+account Upsert #2
+account Upsert #3
+account Upsert #4
+account Upsert #5
+account Upsert #6
+account Upsert #7
+account Upsert #8
+account Upsert #9


### PR DESCRIPTION
### What does this PR do?
Updates `detectDelimiter` utility to fallback to `COMMA` if it can't find the delimiter used in a CSV file:
https://github.com/salesforcecli/plugin-data/pull/1110#issuecomment-2545106587

We already do this for `data delete bulk` (the CSV is required to be just 1-column of record IDs):
https://github.com/salesforcecli/plugin-data/blob/1b02e4a60f3944a8e208fa7bf86475815481212a/src/bulkIngest.ts#L74

We set it to `COMMA` in the payload but any valid delimiter works, the API defaults to `COMMA` if not specified anyway:
https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/create_job.htm

### What issues does this PR fix or reference?
@W-17443248@