### PR TITLE
fix: remove deprecations W-18057437

### DIFF
--- a/src/commands/data/delete/resume.ts
+++ b/src/commands/data/delete/resume.ts
@@ -40,7 +40,7 @@ export default class DeleteResume extends SfCommand<BulkResultV2> {
 
     const {
       options: { connection: conn },
-    } = await cache.resolveResumeOptionsFromCache(flags['job-id'] ?? flags['use-most-recent'], true);
+    } = await cache.resolveResumeOptionsFromCache(flags['job-id'] ?? flags['use-most-recent']);
 
     const job = conn.bulk2.job('ingest', {
       id: res.jobId,

--- a/src/commands/data/upsert/resume.ts
+++ b/src/commands/data/upsert/resume.ts
@@ -39,7 +39,7 @@ export default class UpsertResume extends SfCommand<BulkResultV2> {
 
     const {
       options: { connection: conn },
-    } = await cache.resolveResumeOptionsFromCache(flags['job-id'] ?? flags['use-most-recent'], true);
+    } = await cache.resolveResumeOptionsFromCache(flags['job-id'] ?? flags['use-most-recent']);
 
     const job = conn.bulk2.job('ingest', {
       id: res.jobId,

--- a/test/commands/data/dataBulk.nut.ts
+++ b/test/commands/data/dataBulk.nut.ts
@@ -10,7 +10,6 @@ import fs from 'node:fs';
 import os from 'node:os';
 import { expect, config as chaiConfig } from 'chai';
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
-import { sleep } from '@salesforce/kit';
 import { ensurePlainObject } from '@salesforce/ts-types';
 import type { BulkResultV2 } from '../../../src/types.js';
 import type { QueryResult } from '../data/query/query.nut.js';
@@ -18,45 +17,6 @@ import type { QueryResult } from '../data/query/query.nut.js';
 chaiConfig.truncateThreshold = 0;
 
 let testSession: TestSession;
-
-/** Verify that the operation completed successfully and results are available before attempting to do stuff with the results */
-const isCompleted = async (cmd: string): Promise<void> => {
-  let complete = false;
-  while (!complete) {
-    // eslint-disable-next-line no-await-in-loop
-    await sleep(2000);
-    const result = execCmd<BulkResultV2>(cmd);
-    if (result.jsonOutput?.status === 0) {
-      if (result.jsonOutput.result.jobInfo.state === 'JobComplete') {
-        complete = true;
-      }
-    }
-  }
-};
-
-/* Check the status of the bulk upsert job using json output to determine progress
- * The four states of a job are Queued, JobComplete, InProgress, and Aborted. If Aborted, the test will fail
- * Otherwise run status until job is JobComplete
- */
-const checkBulkResumeJsonResponse = (jobId: string, operation: 'delete' | 'upsert'): void => {
-  const statusResponse = execCmd<BulkResultV2>(`data:${operation}:resume --job-id ${jobId} --json`, {
-    ensureExitCode: 0,
-  }).jsonOutput?.result;
-  expect(statusResponse?.jobInfo.state).to.equal('JobComplete');
-  expect(statusResponse?.records?.successfulResults).to.be.an('array').with.lengthOf(10);
-};
-
-/* Check the status of the bulk upsert job using human output to determine progress
- * The four states of a job are Queued, JobComplete, InProgress, and Aborted. If Aborted, the test will fail
- * Otherwise run status until job is JobComplete
- */
-const checkBulkStatusHumanResponse = (statusCommand: string): void => {
-  const statusResponse = execCmd(statusCommand, {
-    ensureExitCode: 0,
-  }).shellOutput.stdout.split(os.EOL);
-  const jobState = statusResponse.find((line) => line.includes('Status'));
-  expect(jobState).to.include('JobComplete');
-};
 
 describe('data:bulk commands', () => {
   before(async () => {
@@ -79,20 +39,41 @@ describe('data:bulk commands', () => {
   describe('data:bulk verify json and human responses', () => {
     describe('data:upsert:bulk then data:upsert:resume then soql:query and data:delete:bulk', () => {
       it('should upsert, query, and delete 10 accounts', async () => {
-        const bulkUpsertResult: BulkResultV2 = bulkInsertAccounts();
-        let jobInfo = bulkUpsertResult.jobInfo;
-        expect(jobInfo).to.have.property('id');
-        await isCompleted(`data:upsert:resume --job-id ${jobInfo.id} --json`);
+        const cmd = `data:upsert:bulk --sobject Account --file ${path.join(
+          '.',
+          'data',
+          'bulkUpsert.csv'
+        )} --external-id Id --json --wait 10 --column-delimiter COMMA`;
+        const rawResponse = execCmd(cmd);
+        const response: BulkResultV2 | undefined = rawResponse.jsonOutput?.result as BulkResultV2;
 
-        checkBulkStatusHumanResponse(`data:upsert:resume --job-id ${jobInfo.id}`);
-        checkBulkResumeJsonResponse(jobInfo.id, 'upsert');
+        expect(response.jobInfo).to.have.property('id');
+        expect(response.jobInfo.state).to.equal('JobComplete');
+        expect(response.records?.successfulResults).to.be.an('array').with.lengthOf(10);
+        const bulkUpsertResult = response.records?.successfulResults[0];
+        assert(Object.keys(ensurePlainObject(bulkUpsertResult)).includes('sf__Id'));
 
-        const bulkDeleteResult = queryAndBulkDelete();
-        jobInfo = bulkDeleteResult.jobInfo;
-        await isCompleted(`data:delete:resume --job-id ${jobInfo.id} --json`);
+        const records = queryAccountRecords();
 
-        checkBulkStatusHumanResponse(`data:delete:resume --job-id ${jobInfo.id}`);
-        checkBulkResumeJsonResponse(jobInfo.id, 'delete');
+        const accountIds = records.map((account) => account.Id);
+        const idsFile = path.join(testSession.project?.dir ?? '.', 'data', 'deleteAccounts.csv');
+        fs.writeFileSync(idsFile, `Id${os.EOL}${accountIds.join(os.EOL)}${os.EOL}`);
+
+        // Run bulk delete
+        const deleteResponse: BulkResultV2 | undefined = execCmd<Awaited<BulkResultV2>>(
+          `data:delete:bulk --sobject Account --file ${idsFile} --json --wait 10 --line-ending ${
+            os.platform() === 'win32' ? 'CRLF' : 'LF'
+          }`,
+          {
+            ensureExitCode: 0,
+          }
+        ).jsonOutput?.result;
+
+        expect(deleteResponse?.jobInfo).to.have.property('id');
+        expect(deleteResponse?.jobInfo.state).to.equal('JobComplete');
+        expect(deleteResponse?.records?.successfulResults.length).to.equal(10);
+        const bulkDeleteResult = deleteResponse?.records?.successfulResults[0];
+        assert(Object.keys(ensurePlainObject(bulkDeleteResult)).includes('sf__Id'));
       });
     });
   });
@@ -144,47 +125,4 @@ const queryAccountRecords = () => {
   ).jsonOutput?.result ?? { records: [], done: false, totalSize: 0 };
   expect(queryResponse).to.have.property('records').with.lengthOf.above(9);
   return queryResponse.records;
-};
-
-const queryAndBulkDelete = (): BulkResultV2 => {
-  const records = queryAccountRecords();
-
-  const accountIds = records.map((account) => account.Id);
-  const idsFile = path.join(testSession.project?.dir ?? '.', 'data', 'deleteAccounts.csv');
-  fs.writeFileSync(idsFile, `Id${os.EOL}${accountIds.join(os.EOL)}${os.EOL}`);
-
-  // Run bulk delete
-  const deleteResponse: BulkResultV2 | undefined = execCmd<Awaited<BulkResultV2>>(
-    `data:delete:bulk --sobject Account --file ${idsFile} --json --wait 10 --line-ending ${
-      os.platform() === 'win32' ? 'CRLF' : 'LF'
-    }`,
-    {
-      ensureExitCode: 0,
-    }
-  ).jsonOutput?.result;
-
-  assert.equal(deleteResponse?.records?.successfulResults.length, 10);
-  const bulkDeleteResult = deleteResponse?.records?.successfulResults[0];
-  assert('Id' in bulkDeleteResult);
-  return deleteResponse;
-};
-
-/** Bulk upsert 10 accounts */
-const bulkInsertAccounts = (): BulkResultV2 => {
-  const cmd = `data:upsert:bulk --sobject Account --file ${path.join(
-    '.',
-    'data',
-    'bulkUpsert.csv'
-  )} --external-id Id --json --wait 10 --column-delimiter COMMA`;
-  const rawResponse = execCmd(cmd);
-  const response: BulkResultV2 | undefined = rawResponse.jsonOutput?.result as BulkResultV2;
-  if (response?.records) {
-    const records = response.records?.successfulResults;
-    assert.equal(records?.length, 10);
-    const bulkUpsertResult = response.records?.successfulResults[0];
-    assert(Object.keys(ensurePlainObject(bulkUpsertResult)).includes('sf__Id'));
-    const jobInfo = response.jobInfo;
-    assert('id' in jobInfo);
-  }
-  return response;
 };


### PR DESCRIPTION
### What does this PR do?
Removes deprecated functionality for `sf data delete/upsert bulk`:
* Remove record failures from JSON output, should use data bulk results to get failures
* No longer allow resuming sync operations without cache


### What issues does this PR fix or reference?
@W-18057437@