### PR TITLE
W-17774659: deprecate --async flag on async-by-default commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,11 +258,10 @@ Bulk delete records from an org using a CSV file. Uses Bulk API 2.0.
 
 ```
 USAGE
-  $ sf data delete bulk -o <value> -s <value> [--json] [--flags-dir <value>] [--api-version <value>] [-w <value> | -a]
+  $ sf data delete bulk -o <value> -s <value> [--json] [--flags-dir <value>] [--api-version <value>] [-w <value>]
     (--line-ending CRLF|LF -f <value>) [--hard-delete]
 
 FLAGS
-  -a, --async                 Run the command asynchronously.
   -f, --file=<value>          (required) CSV file that contains the IDs of the records to update or delete.
   -o, --target-org=<value>    (required) Username or alias of the target org. Not required if the `target-org`
                               configuration variable is already set.
@@ -419,7 +418,7 @@ Bulk export records from an org into a file using a SOQL query. Uses Bulk API 2.
 ```
 USAGE
   $ sf data export bulk -o <value> --output-file <value> -r csv|json [--json] [--flags-dir <value>] [--api-version
-    <value>] [-w <minutes> | --async] [-q <value> | --query-file <value>] [--all-rows] [--column-delimiter
+    <value>] [-w <minutes>] [-q <value> | --query-file <value>] [--all-rows] [--column-delimiter
     BACKQUOTE|CARET|COMMA|PIPE|SEMICOLON|TAB] [--line-ending LF|CRLF]
 
 FLAGS
@@ -432,7 +431,6 @@ FLAGS
       --all-rows                   Include records that have been soft-deleted due to a merge or delete. By default,
                                    deleted records are not returned.
       --api-version=<value>        Override the api version used for api requests made by this command
-      --async                      Don't wait for the job to complete.
       --column-delimiter=<option>  Column delimiter to be used when writing CSV output. Default is COMMA.
                                    <options: BACKQUOTE|CARET|COMMA|PIPE|SEMICOLON|TAB>
       --line-ending=<option>       Line ending to be used when writing CSV output. Default value on Windows is is
@@ -455,8 +453,7 @@ DESCRIPTION
   both flags. The --output-file flag is required, which means you can only write the records to a file, in either CSV or
   JSON format.
 
-  Bulk exports can take a while, depending on how many records are returned by the SOQL query. If the command times out,
-  or you specified the --async flag, the command displays the job ID. To see the status and get the results of the job,
+  Bulk exports can take a while, depending on how many records are returned by the SOQL query. If the command times out the command displays the job ID. To see the status and get the results of the job,
   run "sf data export resume" and pass the job ID to the --job-id flag.
 
   IMPORTANT: This command uses Bulk API 2.0, which limits the type of SOQL queries you can run. For example, you can't
@@ -481,7 +478,7 @@ EXAMPLES
   command:
 
     $ sf data export bulk --query "SELECT Id, Name, Account.Name FROM Contact" --output-file export-accounts.json \
-      --result-format json --async
+      --result-format json
 ```
 
 _See code: [src/commands/data/export/bulk.ts](https://github.com/salesforcecli/plugin-data/blob/4.0.25/src/commands/data/export/bulk.ts)_
@@ -506,7 +503,7 @@ GLOBAL FLAGS
 DESCRIPTION
   Resume a bulk export job that you previously started. Uses Bulk API 2.0.
 
-  When the original "data export bulk" command either times out or is run with the --async flag, it displays a job ID.
+  When the original "data export bulk" command times out it displays a job ID.
   To see the status and get the results of the bulk export, run this command by either passing it the job ID or using
   the --use-most-recent flag to specify the most recent bulk export job.
 
@@ -656,7 +653,6 @@ USAGE
     (--line-ending CRLF|LF -f <value>) [--column-delimiter BACKQUOTE|CARET|COMMA|PIPE|SEMICOLON|TAB]
 
 FLAGS
-  -a, --async                      Don't wait for the command to complete.
   -f, --file=<value>               (required) CSV file that contains the Salesforce object records you want to import.
   -o, --target-org=<value>         (required) Username or alias of the target org. Not required if the `target-org`
                                    configuration variable is already set.
@@ -682,8 +678,7 @@ DESCRIPTION
 
   All the records in the CSV file must be for the same Salesforce object. Specify the object with the `--sobject` flag.
 
-  Bulk imports can take a while, depending on how many records are in the CSV file. If the command times out, or you
-  specified the --async flag, the command displays the job ID. To see the status and get the results of the job, run "sf
+  Bulk imports can take a while, depending on how many records are in the CSV file. If the command times out the command displays the job ID. To see the status and get the results of the job, run "sf
   data import resume" and pass the job ID to the --job-id flag.
 
   For information and examples about how to prepare your CSV files, see "Prepare Data to Ingest" in the "Bulk API 2.0
@@ -699,7 +694,7 @@ EXAMPLES
   Import asynchronously and use the default org; the command immediately returns a job ID that you then pass to the
   "sf data import resume" command:
 
-    $ sf data import bulk --file accounts.csv --sobject Account --async
+    $ sf data import bulk --file accounts.csv --sobject Account
 ```
 
 _See code: [src/commands/data/import/bulk.ts](https://github.com/salesforcecli/plugin-data/blob/4.0.25/src/commands/data/import/bulk.ts)_
@@ -724,7 +719,7 @@ GLOBAL FLAGS
 DESCRIPTION
   Resume a bulk import job that you previously started. Uses Bulk API 2.0.
 
-  When the original "sf data import bulk" command either times out or is run with the --async flag, it displays a job
+  When the original "sf data import bulk" command times out it displays a job
   ID. To see the status and get the results of the bulk import, run this command by either passing it the job ID or
   using the --use-most-recent flag to specify the most recent bulk import job.
 
@@ -811,7 +806,7 @@ Execute a SOQL query.
 ```
 USAGE
   $ sf data query -o <value> [--json] [--flags-dir <value>] [--api-version <value>] [-q <value>] [-f <value>]
-    [-t | -b] [-w <value> ] [--async ] [--all-rows] [-r human|csv|json] [--output-file <value>]
+    [-t | -b] [-w <value> ] [--all-rows] [-r human|csv|json] [--output-file <value>]
 
 FLAGS
   -b, --bulk                    Use Bulk API 2.0 to run the query.
@@ -825,7 +820,6 @@ FLAGS
   -w, --wait=<value>            Time to wait for the command to finish, in minutes.
       --all-rows                Include deleted records. By default, deleted records are not returned.
       --api-version=<value>     Override the api version used for api requests made by this command
-      --async                   Use Bulk API 2.0, but don't wait for the job to complete.
       --output-file=<value>     File where records are written; only CSV and JSON output formats are supported.
 
 GLOBAL FLAGS
@@ -842,7 +836,7 @@ DESCRIPTION
 
   When using --bulk, the command waits 3 minutes by default for the query to complete. Use the --wait parameter to
   specify a different number of minutes to wait, or set --wait to 0 to immediately return control to the terminal. If
-  you set --wait to 0, or you use the --async flag, or the command simply times out, the command displays an ID. Pass
+  you set --wait to 0, or the command simply times out, the command displays an ID. Pass
   this ID to the the "data query resume" command using the --bulk-query-id flag to get the results; pass the ID to the
   "data resume" command to get the job status.
 
@@ -1004,7 +998,6 @@ USAGE
     (--line-ending CRLF|LF -f <value>) [--column-delimiter BACKQUOTE|CARET|COMMA|PIPE|SEMICOLON|TAB]
 
 FLAGS
-  -a, --async                      Don't wait for the command to complete.
   -f, --file=<value>               (required) CSV file that contains the Salesforce object records you want to update.
   -o, --target-org=<value>         (required) Username or alias of the target org. Not required if the `target-org`
                                    configuration variable is already set.
@@ -1033,8 +1026,7 @@ DESCRIPTION
   contain only existing records; if a record in the file doesn't currently exist in the Salesforce object, the command
   fails. Consider using "sf data upsert bulk" if you also want to insert new records.
 
-  Bulk updates can take a while, depending on how many records are in the CSV file. If the command times out, or you
-  specified the --async flag, the command displays the job ID. To see the status and get the results of the job, run "sf
+  Bulk updates can take a while, depending on how many records are in the CSV file. If the command times out the command displays the job ID. To see the status and get the results of the job, run "sf
   data update resume" and pass the job ID to the --job-id flag.
 
   For information and examples about how to prepare your CSV files, see "Prepare Data to Ingest" in the "Bulk API 2.0
@@ -1050,7 +1042,7 @@ EXAMPLES
   Update asynchronously and use the default org; the command immediately returns a job ID that you then pass to the
   "sf data update resume" command:
 
-    $ sf data update bulk --file accounts.csv --sobject Account --async
+    $ sf data update bulk --file accounts.csv --sobject Account
 ```
 
 _See code: [src/commands/data/update/bulk.ts](https://github.com/salesforcecli/plugin-data/blob/4.0.25/src/commands/data/update/bulk.ts)_
@@ -1137,7 +1129,7 @@ GLOBAL FLAGS
 DESCRIPTION
   Resume a bulk update job that you previously started. Uses Bulk API 2.0.
 
-  When the original "sf data update bulk" command either times out or is run with the --async flag, it displays a job
+  When the original "sf data update bulk" command times out it displays a job
   ID. To see the status and get the results of the bulk update, run this command by either passing it the job ID or
   using the --use-most-recent flag to specify the most recent bulk update job.
 
@@ -1159,11 +1151,9 @@ Bulk upsert records to an org from a CSV file. Uses Bulk API 2.0.
 
 ```
 USAGE
-  $ sf data upsert bulk -o <value> -s <value> -i <value> [--json] [--flags-dir <value>] [--api-version <value>] [-w
-    <value> | -a] (--line-ending CRLF|LF -f <value>) [--column-delimiter BACKQUOTE|CARET|COMMA|PIPE|SEMICOLON|TAB]
+  $ sf data upsert bulk -o <value> -s <value> -i <value> [--json] [--flags-dir <value>] [--api-version <value>] [-w <value>] (--line-ending CRLF|LF -f <value>) [--column-delimiter BACKQUOTE|CARET|COMMA|PIPE|SEMICOLON|TAB]
 
 FLAGS
-  -a, --async                      Run the command asynchronously.
   -f, --file=<value>               (required) CSV file that contains the IDs of the records to update or delete.
   -i, --external-id=<value>        (required) Name of the external ID field, or the Id field.
   -o, --target-org=<value>         (required) Username or alias of the target org. Not required if the `target-org`

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -37,10 +37,9 @@
     "alias": [],
     "command": "data:delete:bulk",
     "flagAliases": ["apiversion", "csvfile", "sobjecttype", "targetusername", "u"],
-    "flagChars": ["a", "f", "o", "s", "w"],
+    "flagChars": ["f", "o", "s", "w"],
     "flags": [
       "api-version",
-      "async",
       "file",
       "flags-dir",
       "hard-delete",
@@ -88,7 +87,6 @@
     "flags": [
       "all-rows",
       "api-version",
-      "async",
       "column-delimiter",
       "flags-dir",
       "json",
@@ -141,10 +139,9 @@
     "alias": [],
     "command": "data:import:bulk",
     "flagAliases": [],
-    "flagChars": ["a", "f", "o", "s", "w"],
+    "flagChars": ["f", "o", "s", "w"],
     "flags": [
       "api-version",
-      "async",
       "column-delimiter",
       "file",
       "flags-dir",
@@ -180,7 +177,6 @@
     "flags": [
       "all-rows",
       "api-version",
-      "async",
       "bulk",
       "file",
       "flags-dir",
@@ -233,10 +229,9 @@
     "alias": [],
     "command": "data:update:bulk",
     "flagAliases": [],
-    "flagChars": ["a", "f", "o", "s", "w"],
+    "flagChars": ["f", "o", "s", "w"],
     "flags": [
       "api-version",
-      "async",
       "column-delimiter",
       "file",
       "flags-dir",
@@ -280,10 +275,9 @@
     "alias": [],
     "command": "data:upsert:bulk",
     "flagAliases": ["apiversion", "csvfile", "externalid", "sobjecttype", "targetusername", "u"],
-    "flagChars": ["a", "f", "i", "o", "s", "w"],
+    "flagChars": ["f", "i", "o", "s", "w"],
     "flags": [
       "api-version",
-      "async",
       "column-delimiter",
       "external-id",
       "file",

--- a/messages/bulkIngest.md
+++ b/messages/bulkIngest.md
@@ -70,10 +70,6 @@ CSV file that contains the IDs of the records to update or delete.
 
 Number of minutes to wait for the command to complete before displaying the results.
 
-# flags.async.summary
-
-Run the command asynchronously.
-
 # flags.jobid
 
 ID of the job you want to resume.

--- a/messages/data.export.bulk.md
+++ b/messages/data.export.bulk.md
@@ -6,9 +6,9 @@ Bulk export records from an org into a file using a SOQL query. Uses Bulk API 2.
 
 You can use this command to export millions of records from an org, either to migrate data or to back it up.
 
-Use a SOQL query to specify the fields of a standard or custom object that you want to export. Specify the SOQL query either at the command line with the --query flag or read it from a file with the --query-file flag; you can't specify both flags. The --output-file flag is required, which means you can only write the records to a file, in either CSV or JSON format. 
+Use a SOQL query to specify the fields of a standard or custom object that you want to export. Specify the SOQL query either at the command line with the --query flag or read it from a file with the --query-file flag; you can't specify both flags. The --output-file flag is required, which means you can only write the records to a file, in either CSV or JSON format.
 
-Bulk exports can take a while, depending on how many records are returned by the SOQL query. If the command times out, or you specified the --async flag, the command displays the job ID. To see the status and get the results of the job, run "sf data export resume" and pass the job ID to the --job-id flag.
+Bulk exports can take a while, depending on how many records are returned by the SOQL query. If the command times out the command displays the job ID. To see the status and get the results of the job, run "sf data export resume" and pass the job ID to the --job-id flag.
 
 IMPORTANT: This command uses Bulk API 2.0, which limits the type of SOQL queries you can run. For example, you can't use aggregate functions such as count(). For the complete list of limitations, see the "SOQL Considerations" section in the "Bulk API 2.0 and Bulk API Developer Guide" (https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/queries.htm).
 
@@ -24,15 +24,11 @@ IMPORTANT: This command uses Bulk API 2.0, which limits the type of SOQL queries
 
 - Export asynchronously; the command immediately returns a job ID that you then pass to the "sf data export resume" command:
 
-  <%= config.bin %> <%= command.id %> --query "SELECT Id, Name, Account.Name FROM Contact" --output-file export-accounts.json --result-format json --async
+  <%= config.bin %> <%= command.id %> --query "SELECT Id, Name, Account.Name FROM Contact" --output-file export-accounts.json --result-format json
 
 # flags.wait.summary
 
 Time to wait for the command to finish, in minutes.
-
-# flags.async.summary
-
-Don't wait for the job to complete.
 
 # flags.query.summary
 

--- a/messages/data.export.resume.md
+++ b/messages/data.export.resume.md
@@ -4,7 +4,7 @@ Resume a bulk export job that you previously started. Uses Bulk API 2.0.
 
 # description
 
-When the original "data export bulk" command either times out or is run with the --async flag, it displays a job ID. To see the status and get the results of the bulk export, run this command by either passing it the job ID or using the --use-most-recent flag to specify the most recent bulk export job.
+When the original "data export bulk" command times out it displays a job ID. To see the status and get the results of the bulk export, run this command by either passing it the job ID or using the --use-most-recent flag to specify the most recent bulk export job.
 
 # flags.job-id.summary
 

--- a/messages/data.import.bulk.md
+++ b/messages/data.import.bulk.md
@@ -8,7 +8,7 @@ You can use this command to import millions of records into the object from a fi
 
 All the records in the CSV file must be for the same Salesforce object. Specify the object with the `--sobject` flag.
 
-Bulk imports can take a while, depending on how many records are in the CSV file. If the command times out, or you specified the --async flag, the command displays the job ID. To see the status and get the results of the job, run "sf data import resume" and pass the job ID to the --job-id flag.
+Bulk imports can take a while, depending on how many records are in the CSV file. If the command times out the command displays the job ID. To see the status and get the results of the job, run "sf data import resume" and pass the job ID to the --job-id flag.
 
 For information and examples about how to prepare your CSV files, see "Prepare Data to Ingest" in the "Bulk API 2.0 and Bulk API Developer Guide" (https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/datafiles_prepare_data.htm).
 
@@ -20,11 +20,7 @@ For information and examples about how to prepare your CSV files, see "Prepare D
 
 - Import asynchronously and use the default org; the command immediately returns a job ID that you then pass to the "sf data import resume" command:
 
-  <%= config.bin %> <%= command.id %> --file accounts.csv --sobject Account --async
-
-# flags.async.summary
-
-Don't wait for the command to complete.
+  <%= config.bin %> <%= command.id %> --file accounts.csv --sobject Account
 
 # flags.file.summary
 

--- a/messages/data.import.resume.md
+++ b/messages/data.import.resume.md
@@ -4,7 +4,7 @@ Resume a bulk import job that you previously started. Uses Bulk API 2.0.
 
 # description
 
-When the original "sf data import bulk" command either times out or is run with the --async flag, it displays a job ID. To see the status and get the results of the bulk import, run this command by either passing it the job ID or using the --use-most-recent flag to specify the most recent bulk import job.
+When the original "sf data import bulk" command times out it displays a job ID. To see the status and get the results of the bulk import, run this command by either passing it the job ID or using the --use-most-recent flag to specify the most recent bulk import job.
 
 # examples
 

--- a/messages/data.update.bulk.md
+++ b/messages/data.update.bulk.md
@@ -8,7 +8,7 @@ You can use this command to update millions of Salesforce object records based o
 
 All the records in the CSV file must be for the same Salesforce object. Specify the object with the `--sobject` flag. The first column of every line in the CSV file must be an ID of the record you want to update. The CSV file can contain only existing records; if a record in the file doesn't currently exist in the Salesforce object, the command fails. Consider using "sf data upsert bulk" if you also want to insert new records.
 
-Bulk updates can take a while, depending on how many records are in the CSV file. If the command times out, or you specified the --async flag, the command displays the job ID. To see the status and get the results of the job, run "sf data update resume" and pass the job ID to the --job-id flag.
+Bulk updates can take a while, depending on how many records are in the CSV file. If the command times out the command displays the job ID. To see the status and get the results of the job, run "sf data update resume" and pass the job ID to the --job-id flag.
 
 For information and examples about how to prepare your CSV files, see "Prepare Data to Ingest" in the "Bulk API 2.0 and Bulk API Developer Guide" (https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/datafiles_prepare_data.htm).
 
@@ -20,11 +20,7 @@ For information and examples about how to prepare your CSV files, see "Prepare D
 
 - Update asynchronously and use the default org; the command immediately returns a job ID that you then pass to the "sf data update resume" command:
 
-  <%= config.bin %> <%= command.id %> --file accounts.csv --sobject Account --async
-
-# flags.async.summary
-
-Don't wait for the command to complete.
+  <%= config.bin %> <%= command.id %> --file accounts.csv --sobject Account
 
 # flags.wait.summary
 

--- a/messages/data.update.resume.md
+++ b/messages/data.update.resume.md
@@ -4,7 +4,7 @@ Resume a bulk update job that you previously started. Uses Bulk API 2.0.
 
 # description
 
-When the original "sf data update bulk" command either times out or is run with the --async flag, it displays a job ID. To see the status and get the results of the bulk update, run this command by either passing it the job ID or using the --use-most-recent flag to specify the most recent bulk update job.
+When the original "sf data update bulk" command times out it displays a job ID. To see the status and get the results of the bulk update, run this command by either passing it the job ID or using the --use-most-recent flag to specify the most recent bulk update job.
 
 # examples
 

--- a/messages/soql.query.md
+++ b/messages/soql.query.md
@@ -8,7 +8,7 @@ Specify the SOQL query at the command line with the --query flag or read the que
 
 If your query returns more than 10,000 records, specify the --bulk flag. The command then runs the query using Bulk API 2.0, which has higher limits than the default API used by the command.
 
-When using --bulk, the command waits 3 minutes by default for the query to complete. Use the --wait parameter to specify a different number of minutes to wait, or set --wait to 0 to immediately return control to the terminal. If you set --wait to 0, or you use the --async flag, or the command simply times out, the command displays an ID. Pass this ID to the the "data query resume" command using the --bulk-query-id flag to get the results; pass the ID to the "data resume" command to get the job status.
+When using --bulk, the command waits 3 minutes by default for the query to complete. Use the --wait parameter to specify a different number of minutes to wait, or set --wait to 0 to immediately return control to the terminal. If you set --wait to 0, or the command simply times out, the command displays an ID. Pass this ID to the the "data query resume" command using the --bulk-query-id flag to get the results; pass the ID to the "data resume" command to get the job status.
 
 # examples
 
@@ -43,10 +43,6 @@ File that contains the SOQL query.
 # flags.bulk.summary
 
 Use Bulk API 2.0 to run the query.
-
-# flags.async.summary
-
-Use Bulk API 2.0, but don't wait for the job to complete.
 
 # flags.all-rows.summary
 

--- a/src/bulkIngest.ts
+++ b/src/bulkIngest.ts
@@ -49,7 +49,6 @@ export async function bulkIngest(opts: {
   externalId?: JobInfoV2['externalIdFieldName'];
   conn: Connection;
   cache: BulkUpdateRequestCache | BulkImportRequestCache | BulkUpsertRequestCache;
-  async: boolean;
   wait: Duration;
   file: string;
   jsonEnabled: boolean;
@@ -63,7 +62,7 @@ export async function bulkIngest(opts: {
     throw new SfError('External ID is only required for `sf data upsert bulk`.');
   }
 
-  const timeout = opts.async ? Duration.minutes(0) : opts.wait ?? Duration.minutes(0);
+  const timeout = opts.wait ?? Duration.minutes(0);
   const async = timeout.milliseconds === 0;
 
   // CSV file for `delete/HardDelete` operations only have 1 column (ID), we set it to `COMMA` if not specified but any delimiter works.
@@ -368,12 +367,6 @@ export const baseUpsertDeleteFlags = {
     summary: messages.getMessage('flags.wait.summary'),
     min: 0,
     defaultValue: 0,
-    exclusive: ['async'],
-  }),
-  async: Flags.boolean({
-    char: 'a',
-    summary: messages.getMessage('flags.async.summary'),
-    exclusive: ['wait'],
   }),
 };
 

--- a/src/commands/data/delete/bulk.ts
+++ b/src/commands/data/delete/bulk.ts
@@ -42,7 +42,6 @@ export default class Delete extends SfCommand<BulkResultV2> {
       columnDelimiter: undefined,
       conn: flags['target-org'].getConnection(flags['api-version']),
       cache: await BulkDeleteRequestCache.create(),
-      async: flags.async,
       wait: flags.wait,
       file: flags.file,
       jsonEnabled: this.jsonEnabled(),

--- a/src/commands/data/export/bulk.ts
+++ b/src/commands/data/export/bulk.ts
@@ -38,11 +38,6 @@ export default class DataExportBulk extends SfCommand<DataExportBulkResult> {
       char: 'w',
       helpValue: '<minutes>',
       unit: 'minutes',
-      exclusive: ['async'],
-    }),
-    async: Flags.boolean({
-      summary: messages.getMessage('flags.async.summary'),
-      exclusive: ['wait'],
     }),
     query: Flags.string({
       summary: messages.getMessage('flags.query.summary'),
@@ -107,7 +102,7 @@ export default class DataExportBulk extends SfCommand<DataExportBulkResult> {
 
     const conn = flags['target-org'].getConnection(flags['api-version']);
 
-    const timeout = flags.async ? Duration.minutes(0) : flags.wait ?? Duration.minutes(0);
+    const timeout = flags.wait ?? Duration.minutes(0);
 
     // `flags['query-file']` will be present if `flags.query` isn't. oclif's `exclusive` isn't quite that clever
     const soqlQuery = flags.query ?? fs.readFileSync(flags['query-file'] as string, 'utf8');

--- a/src/commands/data/import/bulk.ts
+++ b/src/commands/data/import/bulk.ts
@@ -26,11 +26,6 @@ export default class DataImportBulk extends SfCommand<DataImportBulkResult> {
   public static readonly examples = messages.getMessages('examples');
 
   public static readonly flags = {
-    async: Flags.boolean({
-      summary: messages.getMessage('flags.async.summary'),
-      char: 'a',
-      exclusive: ['wait'],
-    }),
     file: Flags.file({
       summary: messages.getMessage('flags.file.summary'),
       char: 'f',
@@ -47,7 +42,6 @@ export default class DataImportBulk extends SfCommand<DataImportBulkResult> {
       summary: messages.getMessage('flags.wait.summary'),
       char: 'w',
       unit: 'minutes',
-      exclusive: ['async'],
     }),
     'target-org': Flags.requiredOrg(),
     'line-ending': Flags.option({
@@ -70,7 +64,6 @@ export default class DataImportBulk extends SfCommand<DataImportBulkResult> {
       columnDelimiter: flags['column-delimiter'],
       conn: flags['target-org'].getConnection(flags['api-version']),
       cache: await BulkImportRequestCache.create(),
-      async: flags.async,
       wait: flags.wait,
       file: flags.file,
       jsonEnabled: this.jsonEnabled(),

--- a/src/commands/data/query.ts
+++ b/src/commands/data/query.ts
@@ -76,12 +76,6 @@ export class DataSoqlQueryCommand extends SfCommand<DataQueryResult> {
       char: 'w',
       summary: messages.getMessage('flags.wait.summary'),
       dependsOn: ['bulk'],
-      exclusive: ['async'],
-    }),
-    async: Flags.boolean({
-      summary: messages.getMessage('flags.async.summary'),
-      dependsOn: ['bulk'],
-      exclusive: ['wait'],
     }),
     'all-rows': Flags.boolean({
       summary: messages.getMessage('flags.all-rows.summary'),
@@ -127,9 +121,9 @@ export class DataSoqlQueryCommand extends SfCommand<DataQueryResult> {
     this.logger = await Logger.child('data:soql:query');
     const flags = (await this.parse(DataSoqlQueryCommand)).flags;
 
-    if (flags.bulk || flags.wait || flags.async) {
+    if (flags.bulk || flags.wait) {
       this
-        .warn(`Bulk mode for "data query" is deprecated, the following flags will be removed after April 2025: --bulk | --wait | --async.
+        .warn(`Bulk mode for "data query" is deprecated, the following flags will be removed after April 2025: --bulk | --wait.
 Use "data export bulk" for bulk queries instead.
 `);
     }
@@ -140,12 +134,7 @@ Use "data export bulk" for bulk queries instead.
       const conn = flags['target-org'].getConnection(flags['api-version']);
       if (flags['result-format'] !== 'json') this.spinner.start(messages.getMessage('queryRunningMessage'));
       const queryResult = flags.bulk
-        ? await this.runBulkSoqlQuery(
-            conn,
-            queryString,
-            flags.async ? Duration.minutes(0) : flags.wait ?? Duration.minutes(0),
-            flags['all-rows'] === true
-          )
+        ? await this.runBulkSoqlQuery(conn, queryString, flags.wait ?? Duration.minutes(0), flags['all-rows'] === true)
         : await this.runSoqlQuery(
             flags['use-tooling-api'] ? conn.tooling : conn,
             queryString,

--- a/src/commands/data/update/bulk.ts
+++ b/src/commands/data/update/bulk.ts
@@ -26,10 +26,6 @@ export default class DataUpdateBulk extends SfCommand<DataUpdateBulkResult> {
   public static readonly examples = messages.getMessages('examples');
 
   public static readonly flags = {
-    async: Flags.boolean({
-      summary: messages.getMessage('flags.async.summary'),
-      char: 'a',
-    }),
     wait: Flags.duration({
       summary: messages.getMessage('flags.wait.summary'),
       char: 'w',
@@ -64,7 +60,6 @@ export default class DataUpdateBulk extends SfCommand<DataUpdateBulkResult> {
       columnDelimiter: flags['column-delimiter'],
       conn: flags['target-org'].getConnection(flags['api-version']),
       cache: await BulkUpdateRequestCache.create(),
-      async: flags.async,
       wait: flags.wait,
       file: flags.file,
       jsonEnabled: this.jsonEnabled(),

--- a/src/commands/data/upsert/bulk.ts
+++ b/src/commands/data/upsert/bulk.ts
@@ -46,7 +46,6 @@ export default class Upsert extends SfCommand<BulkResultV2> {
       externalId: flags['external-id'],
       conn: flags['target-org'].getConnection(flags['api-version']),
       cache: await BulkUpsertRequestCache.create(),
-      async: flags.async,
       wait: flags.wait,
       file: flags.file,
       jsonEnabled: this.jsonEnabled(),

--- a/test/commands/data/bulk/results.nut.ts
+++ b/test/commands/data/bulk/results.nut.ts
@@ -63,7 +63,7 @@ describe('data bulk results NUTs', () => {
     const csvFile = await generateAccountsCsv(session.project.dir, 5000);
 
     const bulkImportAsync = execCmd<DataImportBulkResult>(
-      `data import bulk --file ${csvFile} --sobject account --async --json`,
+      `data import bulk --file ${csvFile} --sobject account --json`,
       { ensureExitCode: 0 }
     ).jsonOutput?.result as DataImportBulkResult;
 

--- a/test/commands/data/export/resume.nut.ts
+++ b/test/commands/data/export/resume.nut.ts
@@ -47,7 +47,7 @@ describe('data export resume NUTs', () => {
 
   it('should resume export in csv format', async () => {
     const outputFile = 'export-accounts.csv';
-    const command = `data export bulk -q "${soqlQuery}" --output-file ${outputFile} --async --json`;
+    const command = `data export bulk -q "${soqlQuery}" --output-file ${outputFile} --json`;
 
     const exportAsyncResult = execCmd<DataExportBulkResult>(command, { ensureExitCode: 0 }).jsonOutput?.result;
 
@@ -71,7 +71,7 @@ describe('data export resume NUTs', () => {
 
   it('should resume export in json format', async () => {
     const outputFile = 'export-accounts.json';
-    const command = `data export bulk -q "${soqlQuery}" --output-file ${outputFile} --async --result-format json --json`;
+    const command = `data export bulk -q "${soqlQuery}" --output-file ${outputFile} --result-format json --json`;
 
     const exportAsyncResult = execCmd<DataExportBulkResult>(command, { ensureExitCode: 0 }).jsonOutput?.result;
 

--- a/test/commands/data/import/resume.nut.ts
+++ b/test/commands/data/import/resume.nut.ts
@@ -35,7 +35,7 @@ describe('data import resume NUTs', () => {
     const csvFile = await generateAccountsCsv(session.dir);
 
     const importAsyncRes = execCmd<DataImportBulkResult>(
-      `data import bulk --file ${csvFile} --sobject account --async --json`,
+      `data import bulk --file ${csvFile} --sobject account --json`,
       { ensureExitCode: 0 }
     ).jsonOutput?.result;
 
@@ -59,7 +59,7 @@ describe('data import resume NUTs', () => {
   it('should resume bulk import via--use-most-recent', async () => {
     const csvFile = await generateAccountsCsv(session.dir);
 
-    const command = `data import bulk --file ${csvFile} --sobject account --async --json`;
+    const command = `data import bulk --file ${csvFile} --sobject account --json`;
 
     const exportAsyncResult = execCmd<DataImportBulkResult>(command, { ensureExitCode: 0 }).jsonOutput?.result;
 

--- a/test/commands/data/update/resume.nut.ts
+++ b/test/commands/data/update/resume.nut.ts
@@ -60,7 +60,7 @@ describe('data update resume NUTs', () => {
     );
 
     const dataUpdateAsyncRes = execCmd<DataUpdateBulkResult>(
-      `data update bulk --file ${updatedCsv} --sobject account --async --json`,
+      `data update bulk --file ${updatedCsv} --sobject account --json`,
       { ensureExitCode: 0 }
     ).jsonOutput?.result;
 


### PR DESCRIPTION
### What does this PR do?
Removes the --async flag in the following commands:

1. data delete bulk
2. data export bulk
3. data import bulk
4. data query
5. data update bulk
6. data upset bulk

These commands already run asynchronously by default.

### What issues does this PR fix or reference?
[@W-17774659@ >](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000029IIaZYAW/view)