### PR TITLE
W-17774659: deprecate --async flag on async-by-default commands

### DIFF
--- a/src/bulkIngest.ts
+++ b/src/bulkIngest.ts
@@ -374,6 +374,7 @@ export const baseUpsertDeleteFlags = {
     char: 'a',
     summary: messages.getMessage('flags.async.summary'),
     exclusive: ['wait'],
+    deprecated: true,
   }),
 };
 

--- a/src/commands/data/export/bulk.ts
+++ b/src/commands/data/export/bulk.ts
@@ -43,6 +43,7 @@ export default class DataExportBulk extends SfCommand<DataExportBulkResult> {
     async: Flags.boolean({
       summary: messages.getMessage('flags.async.summary'),
       exclusive: ['wait'],
+      deprecated: true,
     }),
     query: Flags.string({
       summary: messages.getMessage('flags.query.summary'),

--- a/src/commands/data/import/bulk.ts
+++ b/src/commands/data/import/bulk.ts
@@ -30,6 +30,7 @@ export default class DataImportBulk extends SfCommand<DataImportBulkResult> {
       summary: messages.getMessage('flags.async.summary'),
       char: 'a',
       exclusive: ['wait'],
+      deprecated: true,
     }),
     file: Flags.file({
       summary: messages.getMessage('flags.file.summary'),

--- a/src/commands/data/query.ts
+++ b/src/commands/data/query.ts
@@ -82,6 +82,7 @@ export class DataSoqlQueryCommand extends SfCommand<DataQueryResult> {
       summary: messages.getMessage('flags.async.summary'),
       dependsOn: ['bulk'],
       exclusive: ['wait'],
+      deprecated: true,
     }),
     'all-rows': Flags.boolean({
       summary: messages.getMessage('flags.all-rows.summary'),

--- a/src/commands/data/update/bulk.ts
+++ b/src/commands/data/update/bulk.ts
@@ -29,6 +29,7 @@ export default class DataUpdateBulk extends SfCommand<DataUpdateBulkResult> {
     async: Flags.boolean({
       summary: messages.getMessage('flags.async.summary'),
       char: 'a',
+      deprecated: true,
     }),
     wait: Flags.duration({
       summary: messages.getMessage('flags.wait.summary'),


### PR DESCRIPTION
### What does this PR do?
Deprecates the --async flag in the following commands:

1. data delete bulk
2. data export bulk
3. data import bulk
4. data query
5. data update bulk
6. data upset bulk

These commands already run asynchronously by default.
### What issues does this PR fix or reference?
[@W-17774659@ ](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000029IIaZYAW/view)
