### PR TITLE
fix: typos, grammar errors, and incorrect import resume stage title

### DIFF
--- a/messages/bulk.status.md
+++ b/messages/bulk.status.md
@@ -12,7 +12,7 @@ Run this command using the job ID or batch ID returned from the "<%= config.bin 
 
   <%= config.bin %> <%= command.id %> --job-id 750xx000000005sAAA
 
-- View the status of a bulk load job and a specific batches in an org with alias my-scratch:
+- View the status of a bulk load job and a specific batch in an org with alias my-scratch:
 
   <%= config.bin %> <%= command.id %> --job-id 750xx000000005sAAA --batch-id 751xx000000005nAAA --target-org my-scratch
 

--- a/messages/bulk.upsert.md
+++ b/messages/bulk.upsert.md
@@ -16,7 +16,7 @@ By default, the job runs the batches in parallel, which we recommend. You can ru
 
 - Bulk upsert records to the Contact object in your default org:
 
-  <%= config.bin %> --sobject Contact --file files/contacts.csv --external-id Id
+  <%= config.bin %> <%= command.id %> --sobject Contact --file files/contacts.csv --external-id Id
 
 - Bulk upsert records to a custom object in an org with alias my-scratch and wait 5 minutes for the command to complete:
 

--- a/messages/data.resume.md
+++ b/messages/data.resume.md
@@ -12,7 +12,7 @@ Run this command using the job ID or batch ID returned from the "<%= config.bin 
 
   <%= config.bin %> <%= command.id %> --job-id 750xx000000005sAAA
 
-- View the status of a bulk load job and a specific batches:
+- View the status of a bulk load job and a specific batch:
 
   <%= config.bin %> <%= command.id %> --job-id 750xx000000005sAAA --batch-id 751xx000000005nAAA
 

--- a/messages/importApi.md
+++ b/messages/importApi.md
@@ -34,7 +34,7 @@ There are references in a data file %s that can't be resolved:
 
 # error.RefsInFiles
 
-The file %s includes references (ex: '@AccountRef1'). Those are only supported with --plan, not --files.`
+The file %s includes references (ex: '@AccountRef1'). Those are only supported with --plan, not --files.
 
 # error.noRecordTypeName
 

--- a/messages/record.update.md
+++ b/messages/record.update.md
@@ -6,7 +6,7 @@ Updates a single record of a Salesforce or Tooling API object.
 
 Specify the record you want to update with either its ID or with a list of field-value pairs that identify the record. If your list of fields identifies more than one record, the update fails; the error displays how many records were found.
 
-When using field-value pairs for both identifying the record and specifiyng the new field values, use the format <fieldName>=<value>. Enclose all field-value pairs in one set of double quotation marks, delimited by spaces. Enclose values that contain spaces in single quotes.
+When using field-value pairs for both identifying the record and specifying the new field values, use the format <fieldName>=<value>. Enclose all field-value pairs in one set of double quotation marks, delimited by spaces. Enclose values that contain spaces in single quotes.
 
 This command updates a record in Salesforce objects by default. Use the --use-tooling-api flag to update a Tooling API object.
 

--- a/messages/tree.import.md
+++ b/messages/tree.import.md
@@ -22,7 +22,7 @@ Plan definition file to insert multiple data files.
 
 # flags.plan.description
 
-Unlike when you use the `--files` flag, the files listed in the plan definition file **can** contain more then 200 records. When the CLI executes the import, it automatically batches the records to comply with the 200 record limit set by the API.
+Unlike when you use the `--files` flag, the files listed in the plan definition file **can** contain more than 200 records. When the CLI executes the import, it automatically batches the records to comply with the 200 record limit set by the API.
 
 The order in which you list the files in the plan definition file matters. Specifically, records with lookups to records in another file should be listed AFTER that file. For example, let's say you're loading Account and Contact records, and the contacts have references to those accounts. Be sure you list the Accounts file before the Contacts file.
 

--- a/src/api/data/tree/importFiles.ts
+++ b/src/api/data/tree/importFiles.ts
@@ -74,7 +74,7 @@ const logFileInfo =
     return fileInfo;
   };
 
-/** check the tree files for references, throw error telling user they are only supported with `--plan */
+/** check the tree files for references, throw error telling user they are only supported with `--plan` */
 export const validateNoRefs = (fileInfo: FileInfo): FileInfo => {
   if (hasUnresolvedRefs(fileInfo.records)) {
     Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);

--- a/src/bulkIngest.ts
+++ b/src/bulkIngest.ts
@@ -365,7 +365,7 @@ export const lineEndingFlag = Flags.option({
 })();
 
 /**
- * Use only for commands that maintain sfdx compatibility.1
+ * Use only for commands that maintain sfdx compatibility.
  *
  * @deprecated
  */

--- a/src/bulkUtils.ts
+++ b/src/bulkUtils.ts
@@ -324,11 +324,11 @@ export async function detectDelimiter(filePath: string): Promise<ColumnDelimiter
   }
 
   // default to `COMMA` if no delimiter was found in the CSV file (1 column)
-  const columDelimiter = delimiterMap.get(detectedDelimiter ?? ',');
+  const columnDelimiter = delimiterMap.get(detectedDelimiter ?? ',');
 
-  if (columDelimiter === undefined) {
+  if (columnDelimiter === undefined) {
     throw new SfError(`Failed to detect column delimiter used in ${filePath}.`);
   }
 
-  return columDelimiter;
+  return columnDelimiter;
 }

--- a/src/commands/data/import/resume.ts
+++ b/src/commands/data/import/resume.ts
@@ -59,7 +59,7 @@ export default class DataImportResume extends SfCommand<DataImportResumeResult> 
 
     return bulkIngestResume({
       cmdId: 'data import resume',
-      stageTitle: 'Updating data',
+      stageTitle: 'Importing data',
       cache: await BulkImportRequestCache.create(),
       jobIdOrMostRecent: flags['job-id'] ?? flags['use-most-recent'],
       jsonEnabled: this.jsonEnabled(),

--- a/src/commands/data/update/record.ts
+++ b/src/commands/data/update/record.ts
@@ -82,7 +82,7 @@ export default class Update extends SfCommand<SaveResult> {
     const conn = flags['use-tooling-api']
       ? flags['target-org'].getConnection(flags['api-version']).tooling
       : flags['target-org'].getConnection(flags['api-version']);
-    // oclif isn't smart of enough to know that if record-id is not set, then where is set
+    // oclif isn't smart enough to know that if record-id is not set, then where is set
     const sObjectId = flags['record-id'] ?? ((await query(conn, flags.sobject, flags.where as string)).Id as string);
     try {
       const updateObject = { ...stringToDictionary(flags.values), Id: sObjectId };


### PR DESCRIPTION
## Summary

Fixes 11 typos, grammar errors, and minor bugs found across messages and source files:

### Messages (CLI help text)
- `record.update.md`: "specifiyng" → "specifying"
- `tree.import.md`: "more then 200" → "more than 200"
- `bulk.status.md` + `data.resume.md`: "a specific batches" → "a specific batch"
- `importApi.md`: removed trailing backtick artifact from error message string
- `bulk.upsert.md`: added missing `<%= command.id %>` template tag in first example (currently renders without the command name)

### Source
- `bulkIngest.ts`: removed stray ".1" suffix in deprecation JSDoc comment
- `bulkUtils.ts`: renamed local variable `columDelimiter` → `columnDelimiter` (typo, missing "n")
- `update/record.ts`: "smart of enough" → "smart enough" in comment
- `importFiles.ts`: fixed unclosed backtick in JSDoc (`--plan` was missing closing backtick)

### Bug fix
- `import/resume.ts`: changed `stageTitle` from `'Updating data'` to `'Importing data'` — every other resume command matches its bulk counterpart (`delete/resume` → "Deleting data", `upsert/resume` → "Upserting data", `update/resume` → "Updating data"), but `import/resume` incorrectly showed "Updating data" instead of "Importing data"

## Test plan
- [ ] All changes are string/comment-only except `columDelimiter` rename (local variable, 3 occurrences in one function) and `stageTitle` fix
- [ ] `yarn build` passes
- [ ] Existing tests pass