### PR TITLE
chore: generated schemas folder (W-23365673)

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
   },
   "devDependencies": {
     "@oclif/core": "^4.11.4",
-    "@oclif/plugin-command-snapshot": "^5.3.22",
+    "@oclif/plugin-command-snapshot": "^5.3.31",
     "@oclif/test": "^4.1.18",
     "@salesforce/cli-plugins-testkit": "^5.3.58",
     "@salesforce/dev-scripts": "^11.0.4",

--- a/schemas/data-bulk-results.json
+++ b/schemas/data-bulk-results.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/DataBulkResultsResult",
+  "definitions": {
+    "DataBulkResultsResult": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["Open", "UploadComplete", "InProgress", "JobComplete", "Aborted", "Failed"]
+        },
+        "operation": {
+          "$ref": "#/definitions/IngestOperation"
+        },
+        "object": {
+          "type": "string"
+        },
+        "processedRecords": {
+          "type": "number"
+        },
+        "successfulRecords": {
+          "type": "number"
+        },
+        "failedRecords": {
+          "type": "number"
+        },
+        "successFilePath": {
+          "type": "string"
+        },
+        "failedFilePath": {
+          "type": "string"
+        },
+        "unprocessedFilePath": {
+          "type": "string"
+        }
+      },
+      "required": ["status", "operation", "object", "processedRecords", "successFilePath"],
+      "additionalProperties": false
+    },
+    "IngestOperation": {
+      "type": "string",
+      "enum": ["insert", "update", "upsert", "delete", "hardDelete"]
+    }
+  }
+}

--- a/schemas/data-create-file.json
+++ b/schemas/data-create-file.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/ContentVersion",
+  "definitions": {
+    "ContentVersion": {
+      "type": "object",
+      "properties": {
+        "Id": {
+          "type": "string"
+        },
+        "attributes": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "required": ["type", "url"]
+        },
+        "Title": {
+          "type": "string"
+        },
+        "FileExtension": {
+          "type": "string"
+        },
+        "VersionData": {
+          "type": "string"
+        },
+        "ContentDocumentId": {
+          "type": "string",
+          "description": "this could be undefined outside of our narrow use case (created files)"
+        }
+      },
+      "required": ["ContentDocumentId", "FileExtension", "Title", "VersionData"]
+    }
+  }
+}

--- a/schemas/data-create-record.json
+++ b/schemas/data-create-record.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/SaveResult",
+  "definitions": {
+    "SaveResult": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "success": {
+              "type": "boolean",
+              "const": true
+            },
+            "id": {
+              "type": "string"
+            },
+            "errors": {
+              "type": "array",
+              "items": {
+                "not": {}
+              }
+            }
+          },
+          "required": ["success", "id", "errors"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "success": {
+              "type": "boolean",
+              "const": false
+            },
+            "id": {
+              "not": {}
+            },
+            "errors": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SaveError"
+              }
+            }
+          },
+          "required": ["success", "errors"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "SaveError": {
+      "type": "object",
+      "properties": {
+        "errorCode": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": ["errorCode", "message"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/data-delete-resume.json
+++ b/schemas/data-delete-resume.json
@@ -1,0 +1,166 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/BulkResultV2",
+  "definitions": {
+    "BulkResultV2": {
+      "type": "object",
+      "properties": {
+        "jobInfo": {
+          "$ref": "#/definitions/JobInfoV2"
+        },
+        "records": {
+          "$ref": "#/definitions/BulkRecordsV2"
+        }
+      },
+      "required": ["jobInfo"],
+      "additionalProperties": false
+    },
+    "JobInfoV2": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "apexProcessingTime": {
+          "type": "number"
+        },
+        "apiActiveProcessingTime": {
+          "type": "number"
+        },
+        "assignmentRuleId": {
+          "type": "string"
+        },
+        "contentUrl": {
+          "type": "string"
+        },
+        "errorMessage": {
+          "type": "string"
+        },
+        "externalIdFieldName": {
+          "type": "string"
+        },
+        "jobType": {
+          "type": "string",
+          "enum": ["BigObjectIngest", "Classic", "V2Ingest"]
+        },
+        "operation": {
+          "$ref": "#/definitions/IngestOperation"
+        },
+        "state": {
+          "type": "string",
+          "enum": ["Open", "UploadComplete", "InProgress", "JobComplete", "Aborted", "Failed"]
+        },
+        "numberRecordsFailed": {
+          "type": "number"
+        },
+        "id": {
+          "type": "string"
+        },
+        "object": {
+          "type": "string"
+        },
+        "createdById": {
+          "type": "string"
+        },
+        "createdDate": {
+          "type": "string"
+        },
+        "systemModstamp": {
+          "type": "string"
+        },
+        "apiVersion": {
+          "type": "number"
+        },
+        "lineEnding": {
+          "type": "string",
+          "enum": ["LF", "CRLF"]
+        },
+        "columnDelimiter": {
+          "type": "string",
+          "enum": ["BACKQUOTE", "CARET", "COMMA", "PIPE", "SEMICOLON", "TAB"]
+        },
+        "concurrencyMode": {
+          "type": "string",
+          "const": "Parallel"
+        },
+        "contentType": {
+          "type": "string",
+          "const": "CSV"
+        },
+        "numberRecordsProcessed": {
+          "type": "number"
+        },
+        "retries": {
+          "type": "number"
+        },
+        "totalProcessingTime": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "apexProcessingTime",
+        "apiActiveProcessingTime",
+        "apiVersion",
+        "columnDelimiter",
+        "concurrencyMode",
+        "contentType",
+        "contentUrl",
+        "createdById",
+        "createdDate",
+        "id",
+        "jobType",
+        "lineEnding",
+        "numberRecordsFailed",
+        "numberRecordsProcessed",
+        "object",
+        "operation",
+        "retries",
+        "state",
+        "systemModstamp",
+        "totalProcessingTime"
+      ]
+    },
+    "IngestOperation": {
+      "type": "string",
+      "enum": ["insert", "update", "upsert", "delete", "hardDelete"]
+    },
+    "BulkRecordsV2": {
+      "type": "object",
+      "properties": {
+        "successfulResults": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BulkProcessedRecordV2"
+          }
+        },
+        "failedResults": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BulkProcessedRecordV2"
+          }
+        },
+        "unprocessedRecords": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BulkProcessedRecordV2"
+          }
+        },
+        "unparsed": {
+          "type": "string"
+        }
+      },
+      "required": ["successfulResults", "failedResults", "unprocessedRecords"],
+      "additionalProperties": false
+    },
+    "BulkProcessedRecordV2": {
+      "type": "object",
+      "properties": {
+        "sf__Created": {
+          "type": "string",
+          "enum": ["true", "false"]
+        },
+        "sf__Id": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/schemas/data-export-bulk.json
+++ b/schemas/data-export-bulk.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/DataExportBulkResult",
+  "definitions": {
+    "DataExportBulkResult": {
+      "type": "object",
+      "properties": {
+        "jobId": {
+          "type": "string"
+        },
+        "totalSize": {
+          "type": "number"
+        },
+        "filePath": {
+          "type": "string"
+        }
+      },
+      "required": ["filePath"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/data-export-resume.json
+++ b/schemas/data-export-resume.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/DataExportResumeResult",
+  "definitions": {
+    "DataExportResumeResult": {
+      "type": "object",
+      "properties": {
+        "totalSize": {
+          "type": "number"
+        },
+        "filePath": {
+          "type": "string"
+        }
+      },
+      "required": ["totalSize", "filePath"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/data-export-tree.json
+++ b/schemas/data-export-tree.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/ExportTreeResult",
+  "definitions": {
+    "ExportTreeResult": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DataPlanPart"
+          }
+        },
+        {
+          "$ref": "#/definitions/SObjectTreeFileContents"
+        }
+      ]
+    },
+    "DataPlanPart": {
+      "type": "object",
+      "properties": {
+        "sobject": {
+          "type": "string"
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": ["sobject", "files"],
+      "additionalProperties": false
+    },
+    "SObjectTreeFileContents": {
+      "type": "object",
+      "properties": {
+        "records": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SObjectTreeInput"
+          }
+        }
+      },
+      "required": ["records"],
+      "additionalProperties": false
+    },
+    "SObjectTreeInput": {
+      "type": "object",
+      "properties": {
+        "attributes": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "referenceId": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "required": ["referenceId", "type"]
+        }
+      },
+      "required": ["attributes"]
+    }
+  }
+}

--- a/schemas/data-get-record.json
+++ b/schemas/data-get-record.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Record",
+  "definitions": {
+    "Record": {
+      "type": "object",
+      "properties": {
+        "Id": {
+          "type": "string"
+        },
+        "attributes": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "required": ["type", "url"]
+        }
+      }
+    }
+  }
+}

--- a/schemas/data-import-bulk.json
+++ b/schemas/data-import-bulk.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/DataImportBulkResult",
+  "definitions": {
+    "DataImportBulkResult": {
+      "type": "object",
+      "properties": {
+        "jobId": {
+          "type": "string"
+        },
+        "processedRecords": {
+          "type": "number"
+        },
+        "successfulRecords": {
+          "type": "number"
+        },
+        "failedRecords": {
+          "type": "number"
+        }
+      },
+      "required": ["jobId"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/data-import-resume.json
+++ b/schemas/data-import-resume.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/DataImportResumeResult",
+  "definitions": {
+    "DataImportResumeResult": {
+      "type": "object",
+      "properties": {
+        "jobId": {
+          "type": "string"
+        },
+        "processedRecords": {
+          "type": "number"
+        },
+        "successfulRecords": {
+          "type": "number"
+        },
+        "failedRecords": {
+          "type": "number"
+        }
+      },
+      "required": ["jobId"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/data-import-tree.json
+++ b/schemas/data-import-tree.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/ImportResults",
+  "definitions": {
+    "ImportResults": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ImportResult"
+      }
+    },
+    "ImportResult": {
+      "type": "object",
+      "properties": {
+        "refId": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": ["refId", "type", "id"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/data-query.json
+++ b/schemas/data-query.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/DataQueryResult",
+  "definitions": {
+    "DataQueryResult": {
+      "type": "object",
+      "properties": {
+        "records": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Record"
+          }
+        },
+        "totalSize": {
+          "type": "number"
+        },
+        "done": {
+          "type": "boolean"
+        },
+        "outputFile": {
+          "type": "string"
+        }
+      },
+      "required": ["records", "totalSize", "done"],
+      "additionalProperties": false
+    },
+    "Record": {
+      "type": "object",
+      "properties": {
+        "Id": {
+          "type": "string"
+        },
+        "attributes": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "required": ["type", "url"]
+        }
+      }
+    }
+  }
+}

--- a/schemas/data-search.json
+++ b/schemas/data-search.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/SearchResult",
+  "definitions": {
+    "SearchResult": {
+      "type": "object",
+      "properties": {
+        "searchRecords": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Record"
+          }
+        }
+      },
+      "required": ["searchRecords"],
+      "additionalProperties": false
+    },
+    "Record": {
+      "type": "object",
+      "properties": {
+        "Id": {
+          "type": "string"
+        },
+        "attributes": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "required": ["type", "url"]
+        }
+      }
+    }
+  }
+}

--- a/schemas/data-update-bulk.json
+++ b/schemas/data-update-bulk.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/DataUpdateBulkResult",
+  "definitions": {
+    "DataUpdateBulkResult": {
+      "type": "object",
+      "properties": {
+        "jobId": {
+          "type": "string"
+        },
+        "processedRecords": {
+          "type": "number"
+        },
+        "successfulRecords": {
+          "type": "number"
+        },
+        "failedRecords": {
+          "type": "number"
+        }
+      },
+      "required": ["jobId"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/data-update-record.json
+++ b/schemas/data-update-record.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/SaveResult",
+  "definitions": {
+    "SaveResult": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "success": {
+              "type": "boolean",
+              "const": true
+            },
+            "id": {
+              "type": "string"
+            },
+            "errors": {
+              "type": "array",
+              "items": {
+                "not": {}
+              }
+            }
+          },
+          "required": ["success", "id", "errors"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "success": {
+              "type": "boolean",
+              "const": false
+            },
+            "id": {
+              "not": {}
+            },
+            "errors": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SaveError"
+              }
+            }
+          },
+          "required": ["success", "errors"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "SaveError": {
+      "type": "object",
+      "properties": {
+        "errorCode": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": ["errorCode", "message"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/data-update-resume.json
+++ b/schemas/data-update-resume.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/DataUpdateResumeResult",
+  "definitions": {
+    "DataUpdateResumeResult": {
+      "type": "object",
+      "properties": {
+        "jobId": {
+          "type": "string"
+        },
+        "processedRecords": {
+          "type": "number"
+        },
+        "successfulRecords": {
+          "type": "number"
+        },
+        "failedRecords": {
+          "type": "number"
+        }
+      },
+      "required": ["jobId"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/data-upsert-resume.json
+++ b/schemas/data-upsert-resume.json
@@ -1,0 +1,166 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/BulkResultV2",
+  "definitions": {
+    "BulkResultV2": {
+      "type": "object",
+      "properties": {
+        "jobInfo": {
+          "$ref": "#/definitions/JobInfoV2"
+        },
+        "records": {
+          "$ref": "#/definitions/BulkRecordsV2"
+        }
+      },
+      "required": ["jobInfo"],
+      "additionalProperties": false
+    },
+    "JobInfoV2": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "apexProcessingTime": {
+          "type": "number"
+        },
+        "apiActiveProcessingTime": {
+          "type": "number"
+        },
+        "assignmentRuleId": {
+          "type": "string"
+        },
+        "contentUrl": {
+          "type": "string"
+        },
+        "errorMessage": {
+          "type": "string"
+        },
+        "externalIdFieldName": {
+          "type": "string"
+        },
+        "jobType": {
+          "type": "string",
+          "enum": ["BigObjectIngest", "Classic", "V2Ingest"]
+        },
+        "operation": {
+          "$ref": "#/definitions/IngestOperation"
+        },
+        "state": {
+          "type": "string",
+          "enum": ["Open", "UploadComplete", "InProgress", "JobComplete", "Aborted", "Failed"]
+        },
+        "numberRecordsFailed": {
+          "type": "number"
+        },
+        "id": {
+          "type": "string"
+        },
+        "object": {
+          "type": "string"
+        },
+        "createdById": {
+          "type": "string"
+        },
+        "createdDate": {
+          "type": "string"
+        },
+        "systemModstamp": {
+          "type": "string"
+        },
+        "apiVersion": {
+          "type": "number"
+        },
+        "lineEnding": {
+          "type": "string",
+          "enum": ["LF", "CRLF"]
+        },
+        "columnDelimiter": {
+          "type": "string",
+          "enum": ["BACKQUOTE", "CARET", "COMMA", "PIPE", "SEMICOLON", "TAB"]
+        },
+        "concurrencyMode": {
+          "type": "string",
+          "const": "Parallel"
+        },
+        "contentType": {
+          "type": "string",
+          "const": "CSV"
+        },
+        "numberRecordsProcessed": {
+          "type": "number"
+        },
+        "retries": {
+          "type": "number"
+        },
+        "totalProcessingTime": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "apexProcessingTime",
+        "apiActiveProcessingTime",
+        "apiVersion",
+        "columnDelimiter",
+        "concurrencyMode",
+        "contentType",
+        "contentUrl",
+        "createdById",
+        "createdDate",
+        "id",
+        "jobType",
+        "lineEnding",
+        "numberRecordsFailed",
+        "numberRecordsProcessed",
+        "object",
+        "operation",
+        "retries",
+        "state",
+        "systemModstamp",
+        "totalProcessingTime"
+      ]
+    },
+    "IngestOperation": {
+      "type": "string",
+      "enum": ["insert", "update", "upsert", "delete", "hardDelete"]
+    },
+    "BulkRecordsV2": {
+      "type": "object",
+      "properties": {
+        "successfulResults": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BulkProcessedRecordV2"
+          }
+        },
+        "failedResults": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BulkProcessedRecordV2"
+          }
+        },
+        "unprocessedRecords": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BulkProcessedRecordV2"
+          }
+        },
+        "unparsed": {
+          "type": "string"
+        }
+      },
+      "required": ["successfulResults", "failedResults", "unprocessedRecords"],
+      "additionalProperties": false
+    },
+    "BulkProcessedRecordV2": {
+      "type": "object",
+      "properties": {
+        "sf__Created": {
+          "type": "string",
+          "enum": ["true", "false"]
+        },
+        "sf__Id": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/schemas/force-data-bulk-delete.json
+++ b/schemas/force-data-bulk-delete.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/BatcherReturnType",
+  "definitions": {
+    "BatcherReturnType": {
+      "not": {}
+    }
+  }
+}

--- a/schemas/force-data-bulk-status.json
+++ b/schemas/force-data-bulk-status.json
@@ -1,0 +1,159 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/StatusResult",
+  "definitions": {
+    "StatusResult": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BatchInfo"
+          }
+        },
+        {
+          "$ref": "#/definitions/JobInfo"
+        }
+      ]
+    },
+    "BatchInfo": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "jobId": {
+          "type": "string"
+        },
+        "state": {
+          "$ref": "#/definitions/BatchState"
+        },
+        "stateMessage": {
+          "type": "string"
+        },
+        "numberRecordsProcessed": {
+          "type": "string"
+        },
+        "numberRecordsFailed": {
+          "type": "string"
+        },
+        "totalProcessingTime": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "jobId",
+        "state",
+        "stateMessage",
+        "numberRecordsProcessed",
+        "numberRecordsFailed",
+        "totalProcessingTime"
+      ],
+      "additionalProperties": false
+    },
+    "BatchState": {
+      "type": "string",
+      "enum": ["Queued", "InProgress", "Completed", "Failed", "NotProcessed"]
+    },
+    "JobInfo": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "object": {
+          "type": "string"
+        },
+        "operation": {
+          "$ref": "#/definitions/BulkOperation"
+        },
+        "state": {
+          "$ref": "#/definitions/JobState"
+        },
+        "createdById": {
+          "type": "string"
+        },
+        "createdDate": {
+          "type": "string"
+        },
+        "systemModstamp": {
+          "type": "string"
+        },
+        "concurrencyMode": {
+          "type": "string"
+        },
+        "contentType": {
+          "type": "string"
+        },
+        "numberBatchesQueued": {
+          "type": "string"
+        },
+        "numberBatchesInProgress": {
+          "type": "string"
+        },
+        "numberBatchesCompleted": {
+          "type": "string"
+        },
+        "numberBatchesFailed": {
+          "type": "string"
+        },
+        "numberBatchesTotal": {
+          "type": "string"
+        },
+        "numberRecordsProcessed": {
+          "type": "string"
+        },
+        "numberRetries": {
+          "type": "string"
+        },
+        "apiVersion": {
+          "type": "string"
+        },
+        "numberRecordsFailed": {
+          "type": "string"
+        },
+        "totalProcessingTime": {
+          "type": "string"
+        },
+        "apiActiveProcessingTime": {
+          "type": "string"
+        },
+        "apexProcessingTime": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "object",
+        "operation",
+        "state",
+        "createdById",
+        "createdDate",
+        "systemModstamp",
+        "concurrencyMode",
+        "contentType",
+        "numberBatchesQueued",
+        "numberBatchesInProgress",
+        "numberBatchesCompleted",
+        "numberBatchesFailed",
+        "numberBatchesTotal",
+        "numberRecordsProcessed",
+        "numberRetries",
+        "apiVersion",
+        "numberRecordsFailed",
+        "totalProcessingTime",
+        "apiActiveProcessingTime",
+        "apexProcessingTime"
+      ],
+      "additionalProperties": false
+    },
+    "BulkOperation": {
+      "type": "string",
+      "enum": ["insert", "update", "upsert", "delete", "hardDelete", "query", "queryAll"]
+    },
+    "JobState": {
+      "type": "string",
+      "enum": ["Open", "Closed", "Aborted", "Failed", "Unknown", "NotProcessed"]
+    }
+  }
+}

--- a/schemas/force-data-bulk-upsert.json
+++ b/schemas/force-data-bulk-upsert.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/BatcherReturnType",
+  "definitions": {
+    "BatcherReturnType": {
+      "not": {}
+    }
+  }
+}

--- a/src/api/data/tree/importTypes.ts
+++ b/src/api/data/tree/importTypes.ts
@@ -50,3 +50,5 @@ export type ImportResult = {
   type: string;
   id: string;
 }; /** like the original DataPlanPart but without the non-string options inside files */
+
+export type ImportResults = ImportResult[];

--- a/src/commands/data/import/tree.ts
+++ b/src/commands/data/import/tree.ts
@@ -20,7 +20,7 @@ import { ensureString, isObject } from '@salesforce/ts-types';
 import { importFromPlan } from '../../../api/data/tree/importPlan.js';
 import { importFromFiles } from '../../../api/data/tree/importFiles.js';
 import { orgFlags } from '../../../flags.js';
-import type { ImportResult, TreeResponse } from '../../../api/data/tree/importTypes.js';
+import type { ImportResults, TreeResponse } from '../../../api/data/tree/importTypes.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-data', 'tree.import');
@@ -28,7 +28,7 @@ const messages = Messages.loadMessages('@salesforce/plugin-data', 'tree.import')
 /**
  * Command that provides data import capability via the SObject Tree Save API.
  */
-export default class Import extends SfCommand<ImportResult[]> {
+export default class Import extends SfCommand<ImportResults> {
   public static readonly summary = messages.getMessage('summary');
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
@@ -55,7 +55,7 @@ export default class Import extends SfCommand<ImportResult[]> {
     }),
   };
 
-  public async run(): Promise<ImportResult[]> {
+  public async run(): Promise<ImportResults> {
     const { flags } = await this.parse(Import);
 
     const conn = flags['target-org'].getConnection(flags['api-version']);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1440,10 +1440,10 @@
     react "^18.3.1"
     wrap-ansi "^9.0.2"
 
-"@oclif/plugin-command-snapshot@^5.3.22":
-  version "5.3.22"
-  resolved "https://registry.yarnpkg.com/@oclif/plugin-command-snapshot/-/plugin-command-snapshot-5.3.22.tgz#266853b2e4f327b9051720c444e8d3f15f3058e7"
-  integrity sha512-rbJ8+lTTAPr1CAoqpsRoKBkyMMCwWojSaf+8T8Q7tFltBxCrmNavKTzWKqL7GTTMXKme7jYleZVOxSM2T1A5xg==
+"@oclif/plugin-command-snapshot@^5.3.31":
+  version "5.3.31"
+  resolved "https://registry.yarnpkg.com/@oclif/plugin-command-snapshot/-/plugin-command-snapshot-5.3.31.tgz#1064f54273cead813d90c07604c16c3e99f07850"
+  integrity sha512-jDfwOlgIK+p8Q/YZcBsExZPGeFArtFZ5tqWV+tkW/fKLMMAIbKcrW/NPFFTGsaS3tL8nJfeqyT0f4e5ODd+vDA==
   dependencies:
     "@oclif/core" "^4"
     ansis "^3.17.0"
@@ -1452,8 +1452,8 @@
     lodash.difference "^4.5.0"
     lodash.get "^4.4.2"
     lodash.sortby "^4.7.0"
-    semver "^7.8.1"
-    ts-json-schema-generator "^1.5.1"
+    semver "^7.8.5"
+    ts-json-schema-generator "^2.9.0"
 
 "@oclif/plugin-help@^6.2.49":
   version "6.2.49"
@@ -2937,10 +2937,10 @@ comma-separated-tokens@^2.0.0:
   resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz#4e89c9458acb61bc8fef19f4529973b2392839ee"
   integrity sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==
 
-commander@^12.0.0:
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-12.1.0.tgz#01423b36f501259fdaac4d0e4d60c96c991585d3"
-  integrity sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==
+commander@^14.0.3:
+  version "14.0.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-14.0.3.tgz#425d79b48f9af82fcd9e4fc1ea8af6c5ec07bbc2"
+  integrity sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==
 
 comment-parser@1.4.1:
   version "1.4.1"
@@ -4229,6 +4229,15 @@ glob@^10.3.10:
     package-json-from-dist "^1.0.0"
     path-scurry "^1.11.1"
 
+glob@^13.0.6:
+  version "13.0.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-13.0.6.tgz#078666566a425147ccacfbd2e332deb66a2be71d"
+  integrity sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==
+  dependencies:
+    minimatch "^10.2.2"
+    minipass "^7.1.3"
+    path-scurry "^2.0.2"
+
 glob@^7.0.0, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
@@ -4241,7 +4250,7 @@ glob@^7.0.0, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^8.0.3, glob@^8.1.0:
+glob@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
   integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
@@ -5450,6 +5459,11 @@ lru-cache@^10.0.1, lru-cache@^10.2.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
 
+lru-cache@^11.0.0:
+  version "11.5.2"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.5.2.tgz#00e16665c90c620fba14a3c368732a976493f760"
+  integrity sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==
+
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
@@ -5668,7 +5682,7 @@ minimatch@9.0.3:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^10.2.5:
+minimatch@^10.2.2, minimatch@^10.2.5:
   version "10.2.5"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.5.tgz#bd48687a0be38ed2961399105600f832095861d1"
   integrity sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==
@@ -5710,7 +5724,7 @@ minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
-minipass@7.1.2, "minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
+minipass@7.1.2, "minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2, minipass@^7.1.3:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
   integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
@@ -6203,6 +6217,14 @@ path-scurry@^1.11.1:
   dependencies:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
+
+path-scurry@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-2.0.2.tgz#6be0d0ee02a10d9e0de7a98bae65e182c9061f85"
+  integrity sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==
+  dependencies:
+    lru-cache "^11.0.0"
+    minipass "^7.1.2"
 
 path-to-regexp@^1.7.0:
   version "1.9.0"
@@ -6728,7 +6750,7 @@ safe-regex-test@^1.1.0:
     es-errors "^1.3.0"
     is-regex "^1.2.1"
 
-safe-stable-stringify@^2.3.1, safe-stable-stringify@^2.4.3:
+safe-stable-stringify@^2.3.1, safe-stable-stringify@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz#4ca2f8e385f2831c432a719b108a3bf7af42a1dd"
   integrity sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==
@@ -6776,6 +6798,11 @@ semver@^7.3.4, semver@^7.3.5, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semve
   version "7.8.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.1.tgz#bf4970b5e70fda0686363cc18bfe8805d5ed957e"
   integrity sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==
+
+semver@^7.8.5:
+  version "7.8.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
+  integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
 
 sentence-case@^3.0.4:
   version "3.0.4"
@@ -7417,18 +7444,19 @@ ts-api-utils@^1.0.1, ts-api-utils@^1.3.0:
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.4.3.tgz#bfc2215fe6528fecab2b0fba570a2e8a4263b064"
   integrity sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==
 
-ts-json-schema-generator@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/ts-json-schema-generator/-/ts-json-schema-generator-1.5.1.tgz#7759c421240be86d393a884ad186f926b22332db"
-  integrity sha512-apX5qG2+NA66j7b4AJm8q/DpdTeOsjfh7A3LpKsUiil0FepkNwtN28zYgjrsiiya2/OPhsr/PSjX5FUYg79rCg==
+ts-json-schema-generator@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/ts-json-schema-generator/-/ts-json-schema-generator-2.9.0.tgz#cc2b99db0e64ee9ee6898c8c74905337536ef9fc"
+  integrity sha512-NR5ZE108uiPtBHBJNGnhwoUaUx5vWTDJzDFG9YlRoqxPU76n+5FClRh92dcGgysbe1smRmYalM9Saj97GW1J4Q==
   dependencies:
     "@types/json-schema" "^7.0.15"
-    commander "^12.0.0"
-    glob "^8.0.3"
+    commander "^14.0.3"
+    glob "^13.0.6"
     json5 "^2.2.3"
     normalize-path "^3.0.0"
-    safe-stable-stringify "^2.4.3"
-    typescript "~5.4.2"
+    safe-stable-stringify "^2.5.0"
+    tslib "^2.8.1"
+    typescript "^5.9.3"
 
 ts-node@^10.8.1, ts-node@^10.9.2:
   version "10.9.2"
@@ -7464,7 +7492,7 @@ tsconfig-paths@^3.15.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.0.0, tslib@^2.0.3, tslib@^2.6.2:
+tslib@^2.0.0, tslib@^2.0.3, tslib@^2.6.2, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -7596,15 +7624,10 @@ typedoc@^0.26.5:
     shiki "^1.16.2"
     yaml "^2.5.1"
 
-"typescript@^4.6.4 || ^5.2.2", typescript@^5.5.4, typescript@^5.8.3:
+"typescript@^4.6.4 || ^5.2.2", typescript@^5.5.4, typescript@^5.8.3, typescript@^5.9.3:
   version "5.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
-
-typescript@~5.4.2:
-  version "5.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
-  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
 
 uc.micro@^2.0.0, uc.micro@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
### What does this PR do?

It bumps the dependency on `@oclif/plugin-command-snapshot` to a new version that is capable of generating a `schemas` folder, and generates that folder.

### What issues does this PR fix or reference?
@W-23365673@