### PR TITLE
fix: use ProxyAgent for bulk export results download @W-23816212@

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ EXAMPLES
     $ sf data bulk results --job-id 7507i000fake341G --target-org my-scratch
 ```
 
-_See code: [src/commands/data/bulk/results.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/bulk/results.ts)_
+_See code: [src/commands/data/bulk/results.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.1/src/commands/data/bulk/results.ts)_
 
 ## `sf data create file`
 
@@ -193,7 +193,7 @@ EXAMPLES
     $ sf data create file --file path/to/astro.png --parent-id a03fakeLoJWPIA3
 ```
 
-_See code: [src/commands/data/create/file.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/create/file.ts)_
+_See code: [src/commands/data/create/file.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.1/src/commands/data/create/file.ts)_
 
 ## `sf data create record`
 
@@ -252,7 +252,7 @@ EXAMPLES
       TracedEntityId=01p17000000R6bLAAS"
 ```
 
-_See code: [src/commands/data/create/record.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/create/record.ts)_
+_See code: [src/commands/data/create/record.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.1/src/commands/data/create/record.ts)_
 
 ## `sf data delete bulk`
 
@@ -311,7 +311,7 @@ FLAG DESCRIPTIONS
     and can be enabled only by a system administrator.
 ```
 
-_See code: [src/commands/data/delete/bulk.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/delete/bulk.ts)_
+_See code: [src/commands/data/delete/bulk.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.1/src/commands/data/delete/bulk.ts)_
 
 ## `sf data delete record`
 
@@ -372,7 +372,7 @@ EXAMPLES
     $ sf data delete record --use-tooling-api --sobject TraceFlag --record-id 7tf8c
 ```
 
-_See code: [src/commands/data/delete/record.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/delete/record.ts)_
+_See code: [src/commands/data/delete/record.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.1/src/commands/data/delete/record.ts)_
 
 ## `sf data delete resume`
 
@@ -411,7 +411,7 @@ EXAMPLES
     $ sf data delete resume --use-most-recent --target-org my-scratch
 ```
 
-_See code: [src/commands/data/delete/resume.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/delete/resume.ts)_
+_See code: [src/commands/data/delete/resume.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.1/src/commands/data/delete/resume.ts)_
 
 ## `sf data export bulk`
 
@@ -478,7 +478,7 @@ EXAMPLES
       --result-format json --wait 10 --all-rows
 ```
 
-_See code: [src/commands/data/export/bulk.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/export/bulk.ts)_
+_See code: [src/commands/data/export/bulk.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.1/src/commands/data/export/bulk.ts)_
 
 ## `sf data export resume`
 
@@ -517,7 +517,7 @@ EXAMPLES
     $ sf data export resume --use-most-recent
 ```
 
-_See code: [src/commands/data/export/resume.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/export/resume.ts)_
+_See code: [src/commands/data/export/resume.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.1/src/commands/data/export/resume.ts)_
 
 ## `sf data export tree`
 
@@ -577,7 +577,7 @@ EXAMPLES
       my-scratch
 ```
 
-_See code: [src/commands/data/export/tree.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/export/tree.ts)_
+_See code: [src/commands/data/export/tree.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.1/src/commands/data/export/tree.ts)_
 
 ## `sf data get record`
 
@@ -641,7 +641,7 @@ EXAMPLES
     $ sf data get record --use-tooling-api --sobject TraceFlag --record-id 7tf8c
 ```
 
-_See code: [src/commands/data/get/record.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/get/record.ts)_
+_See code: [src/commands/data/get/record.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.1/src/commands/data/get/record.ts)_
 
 ## `sf data import bulk`
 
@@ -693,7 +693,7 @@ EXAMPLES
     $ sf data import bulk --file accounts.csv --sobject Account --wait 10 --target-org my-scratch
 ```
 
-_See code: [src/commands/data/import/bulk.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/import/bulk.ts)_
+_See code: [src/commands/data/import/bulk.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.1/src/commands/data/import/bulk.ts)_
 
 ## `sf data import resume`
 
@@ -729,7 +729,7 @@ EXAMPLES
     $ sf data import resume --use-most-recent --target-org my-scratch
 ```
 
-_See code: [src/commands/data/import/resume.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/import/resume.ts)_
+_See code: [src/commands/data/import/resume.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.1/src/commands/data/import/resume.ts)_
 
 ## `sf data import tree`
 
@@ -793,7 +793,7 @@ FLAG DESCRIPTIONS
     - files(array) - Files: An array of files paths to load
 ```
 
-_See code: [src/commands/data/import/tree.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/import/tree.ts)_
+_See code: [src/commands/data/import/tree.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.1/src/commands/data/import/tree.ts)_
 
 ## `sf data query`
 
@@ -846,7 +846,7 @@ EXAMPLES
     $ sf data query --query "SELECT Name FROM ApexTrigger" --use-tooling-api
 ```
 
-_See code: [src/commands/data/query.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/query.ts)_
+_See code: [src/commands/data/query.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.1/src/commands/data/query.ts)_
 
 ## `sf data resume`
 
@@ -883,7 +883,7 @@ EXAMPLES
     $ sf data resume --job-id 750xx000000005sAAA --batch-id 751xx000000005nAAA
 ```
 
-_See code: [src/commands/data/resume.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/resume.ts)_
+_See code: [src/commands/data/resume.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.1/src/commands/data/resume.ts)_
 
 ## `sf data search`
 
@@ -933,7 +933,7 @@ EXAMPLES
     $ sf data search --file query.txt --target-org my-scratch --result-format csv
 ```
 
-_See code: [src/commands/data/search.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/search.ts)_
+_See code: [src/commands/data/search.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.1/src/commands/data/search.ts)_
 
 ## `sf data update bulk`
 
@@ -988,7 +988,7 @@ EXAMPLES
     $ sf data update bulk --file accounts.csv --sobject Account --wait 10 --target-org my-scratch
 ```
 
-_See code: [src/commands/data/update/bulk.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/update/bulk.ts)_
+_See code: [src/commands/data/update/bulk.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.1/src/commands/data/update/bulk.ts)_
 
 ## `sf data update record`
 
@@ -1052,7 +1052,7 @@ EXAMPLES
       "ExpirationDate=2017-12-01T00:58:04.000+0000"
 ```
 
-_See code: [src/commands/data/update/record.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/update/record.ts)_
+_See code: [src/commands/data/update/record.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.1/src/commands/data/update/record.ts)_
 
 ## `sf data update resume`
 
@@ -1091,7 +1091,7 @@ EXAMPLES
     $ sf data update resume --use-most-recent
 ```
 
-_See code: [src/commands/data/update/resume.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/update/resume.ts)_
+_See code: [src/commands/data/update/resume.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.1/src/commands/data/update/resume.ts)_
 
 ## `sf data upsert bulk`
 
@@ -1147,7 +1147,7 @@ EXAMPLES
       my-scratch
 ```
 
-_See code: [src/commands/data/upsert/bulk.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/upsert/bulk.ts)_
+_See code: [src/commands/data/upsert/bulk.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.1/src/commands/data/upsert/bulk.ts)_
 
 ## `sf data upsert resume`
 
@@ -1186,7 +1186,7 @@ EXAMPLES
     $ sf data upsert resume --use-most-recent --target-org my-scratch
 ```
 
-_See code: [src/commands/data/upsert/resume.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/upsert/resume.ts)_
+_See code: [src/commands/data/upsert/resume.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.1/src/commands/data/upsert/resume.ts)_
 
 ## `sf force data bulk delete`
 
@@ -1233,7 +1233,7 @@ EXAMPLES
     $ sf force data bulk delete --sobject MyObject__c --file files/delete.csv --wait 5 --target-org my-scratch
 ```
 
-_See code: [src/commands/force/data/bulk/delete.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/force/data/bulk/delete.ts)_
+_See code: [src/commands/force/data/bulk/delete.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.1/src/commands/force/data/bulk/delete.ts)_
 
 ## `sf force data bulk status`
 
@@ -1270,7 +1270,7 @@ EXAMPLES
     $ sf force data bulk status --job-id 750xx000000005sAAA --batch-id 751xx000000005nAAA --target-org my-scratch
 ```
 
-_See code: [src/commands/force/data/bulk/status.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/force/data/bulk/status.ts)_
+_See code: [src/commands/force/data/bulk/status.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.1/src/commands/force/data/bulk/status.ts)_
 
 ## `sf force data bulk upsert`
 
@@ -1328,6 +1328,6 @@ EXAMPLES
       --target-org my-scratch
 ```
 
-_See code: [src/commands/force/data/bulk/upsert.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/force/data/bulk/upsert.ts)_
+_See code: [src/commands/force/data/bulk/upsert.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.1/src/commands/force/data/bulk/upsert.ts)_
 
 <!-- commandsstop -->

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ EXAMPLES
     $ sf data bulk results --job-id 7507i000fake341G --target-org my-scratch
 ```
 
-_See code: [src/commands/data/bulk/results.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.5/src/commands/data/bulk/results.ts)_
+_See code: [src/commands/data/bulk/results.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/bulk/results.ts)_
 
 ## `sf data create file`
 
@@ -193,7 +193,7 @@ EXAMPLES
     $ sf data create file --file path/to/astro.png --parent-id a03fakeLoJWPIA3
 ```
 
-_See code: [src/commands/data/create/file.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.5/src/commands/data/create/file.ts)_
+_See code: [src/commands/data/create/file.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/create/file.ts)_
 
 ## `sf data create record`
 
@@ -252,7 +252,7 @@ EXAMPLES
       TracedEntityId=01p17000000R6bLAAS"
 ```
 
-_See code: [src/commands/data/create/record.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.5/src/commands/data/create/record.ts)_
+_See code: [src/commands/data/create/record.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/create/record.ts)_
 
 ## `sf data delete bulk`
 
@@ -311,7 +311,7 @@ FLAG DESCRIPTIONS
     and can be enabled only by a system administrator.
 ```
 
-_See code: [src/commands/data/delete/bulk.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.5/src/commands/data/delete/bulk.ts)_
+_See code: [src/commands/data/delete/bulk.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/delete/bulk.ts)_
 
 ## `sf data delete record`
 
@@ -372,7 +372,7 @@ EXAMPLES
     $ sf data delete record --use-tooling-api --sobject TraceFlag --record-id 7tf8c
 ```
 
-_See code: [src/commands/data/delete/record.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.5/src/commands/data/delete/record.ts)_
+_See code: [src/commands/data/delete/record.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/delete/record.ts)_
 
 ## `sf data delete resume`
 
@@ -411,7 +411,7 @@ EXAMPLES
     $ sf data delete resume --use-most-recent --target-org my-scratch
 ```
 
-_See code: [src/commands/data/delete/resume.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.5/src/commands/data/delete/resume.ts)_
+_See code: [src/commands/data/delete/resume.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/delete/resume.ts)_
 
 ## `sf data export bulk`
 
@@ -478,7 +478,7 @@ EXAMPLES
       --result-format json --wait 10 --all-rows
 ```
 
-_See code: [src/commands/data/export/bulk.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.5/src/commands/data/export/bulk.ts)_
+_See code: [src/commands/data/export/bulk.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/export/bulk.ts)_
 
 ## `sf data export resume`
 
@@ -517,7 +517,7 @@ EXAMPLES
     $ sf data export resume --use-most-recent
 ```
 
-_See code: [src/commands/data/export/resume.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.5/src/commands/data/export/resume.ts)_
+_See code: [src/commands/data/export/resume.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/export/resume.ts)_
 
 ## `sf data export tree`
 
@@ -577,7 +577,7 @@ EXAMPLES
       my-scratch
 ```
 
-_See code: [src/commands/data/export/tree.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.5/src/commands/data/export/tree.ts)_
+_See code: [src/commands/data/export/tree.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/export/tree.ts)_
 
 ## `sf data get record`
 
@@ -641,7 +641,7 @@ EXAMPLES
     $ sf data get record --use-tooling-api --sobject TraceFlag --record-id 7tf8c
 ```
 
-_See code: [src/commands/data/get/record.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.5/src/commands/data/get/record.ts)_
+_See code: [src/commands/data/get/record.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/get/record.ts)_
 
 ## `sf data import bulk`
 
@@ -693,7 +693,7 @@ EXAMPLES
     $ sf data import bulk --file accounts.csv --sobject Account --wait 10 --target-org my-scratch
 ```
 
-_See code: [src/commands/data/import/bulk.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.5/src/commands/data/import/bulk.ts)_
+_See code: [src/commands/data/import/bulk.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/import/bulk.ts)_
 
 ## `sf data import resume`
 
@@ -729,7 +729,7 @@ EXAMPLES
     $ sf data import resume --use-most-recent --target-org my-scratch
 ```
 
-_See code: [src/commands/data/import/resume.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.5/src/commands/data/import/resume.ts)_
+_See code: [src/commands/data/import/resume.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/import/resume.ts)_
 
 ## `sf data import tree`
 
@@ -793,7 +793,7 @@ FLAG DESCRIPTIONS
     - files(array) - Files: An array of files paths to load
 ```
 
-_See code: [src/commands/data/import/tree.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.5/src/commands/data/import/tree.ts)_
+_See code: [src/commands/data/import/tree.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/import/tree.ts)_
 
 ## `sf data query`
 
@@ -846,7 +846,7 @@ EXAMPLES
     $ sf data query --query "SELECT Name FROM ApexTrigger" --use-tooling-api
 ```
 
-_See code: [src/commands/data/query.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.5/src/commands/data/query.ts)_
+_See code: [src/commands/data/query.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/query.ts)_
 
 ## `sf data resume`
 
@@ -883,7 +883,7 @@ EXAMPLES
     $ sf data resume --job-id 750xx000000005sAAA --batch-id 751xx000000005nAAA
 ```
 
-_See code: [src/commands/data/resume.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.5/src/commands/data/resume.ts)_
+_See code: [src/commands/data/resume.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/resume.ts)_
 
 ## `sf data search`
 
@@ -933,7 +933,7 @@ EXAMPLES
     $ sf data search --file query.txt --target-org my-scratch --result-format csv
 ```
 
-_See code: [src/commands/data/search.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.5/src/commands/data/search.ts)_
+_See code: [src/commands/data/search.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/search.ts)_
 
 ## `sf data update bulk`
 
@@ -988,7 +988,7 @@ EXAMPLES
     $ sf data update bulk --file accounts.csv --sobject Account --wait 10 --target-org my-scratch
 ```
 
-_See code: [src/commands/data/update/bulk.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.5/src/commands/data/update/bulk.ts)_
+_See code: [src/commands/data/update/bulk.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/update/bulk.ts)_
 
 ## `sf data update record`
 
@@ -1052,7 +1052,7 @@ EXAMPLES
       "ExpirationDate=2017-12-01T00:58:04.000+0000"
 ```
 
-_See code: [src/commands/data/update/record.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.5/src/commands/data/update/record.ts)_
+_See code: [src/commands/data/update/record.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/update/record.ts)_
 
 ## `sf data update resume`
 
@@ -1091,7 +1091,7 @@ EXAMPLES
     $ sf data update resume --use-most-recent
 ```
 
-_See code: [src/commands/data/update/resume.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.5/src/commands/data/update/resume.ts)_
+_See code: [src/commands/data/update/resume.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/update/resume.ts)_
 
 ## `sf data upsert bulk`
 
@@ -1147,7 +1147,7 @@ EXAMPLES
       my-scratch
 ```
 
-_See code: [src/commands/data/upsert/bulk.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.5/src/commands/data/upsert/bulk.ts)_
+_See code: [src/commands/data/upsert/bulk.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/upsert/bulk.ts)_
 
 ## `sf data upsert resume`
 
@@ -1186,7 +1186,7 @@ EXAMPLES
     $ sf data upsert resume --use-most-recent --target-org my-scratch
 ```
 
-_See code: [src/commands/data/upsert/resume.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.5/src/commands/data/upsert/resume.ts)_
+_See code: [src/commands/data/upsert/resume.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/data/upsert/resume.ts)_
 
 ## `sf force data bulk delete`
 
@@ -1233,7 +1233,7 @@ EXAMPLES
     $ sf force data bulk delete --sobject MyObject__c --file files/delete.csv --wait 5 --target-org my-scratch
 ```
 
-_See code: [src/commands/force/data/bulk/delete.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.5/src/commands/force/data/bulk/delete.ts)_
+_See code: [src/commands/force/data/bulk/delete.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/force/data/bulk/delete.ts)_
 
 ## `sf force data bulk status`
 
@@ -1270,7 +1270,7 @@ EXAMPLES
     $ sf force data bulk status --job-id 750xx000000005sAAA --batch-id 751xx000000005nAAA --target-org my-scratch
 ```
 
-_See code: [src/commands/force/data/bulk/status.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.5/src/commands/force/data/bulk/status.ts)_
+_See code: [src/commands/force/data/bulk/status.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/force/data/bulk/status.ts)_
 
 ## `sf force data bulk upsert`
 
@@ -1328,6 +1328,6 @@ EXAMPLES
       --target-org my-scratch
 ```
 
-_See code: [src/commands/force/data/bulk/upsert.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.5/src/commands/force/data/bulk/upsert.ts)_
+_See code: [src/commands/force/data/bulk/upsert.ts](https://github.com/salesforcecli/plugin-data/blob/5.1.6-dev.0/src/commands/force/data/bulk/upsert.ts)_
 
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/plugin-data",
-  "version": "5.1.5",
+  "version": "5.1.6-dev.0",
   "description": "Plugin for salesforce data commands",
   "author": "Salesforce",
   "homepage": "https://github.com/salesforcecli/plugin-data",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/plugin-data",
-  "version": "5.1.6-dev.0",
+  "version": "5.1.6-dev.1",
   "description": "Plugin for salesforce data commands",
   "author": "Salesforce",
   "homepage": "https://github.com/salesforcecli/plugin-data",

--- a/src/bulkUtils.ts
+++ b/src/bulkUtils.ts
@@ -19,7 +19,7 @@ import { createInterface } from 'node:readline';
 import { pipeline } from 'node:stream/promises';
 import * as fs from 'node:fs';
 import { EOL } from 'node:os';
-import { fetch } from 'undici';
+import { fetch, ProxyAgent } from 'undici';
 import { HttpResponse } from '@jsforce/jsforce-node';
 import {
   IngestJobV2Results,
@@ -146,9 +146,13 @@ async function bulkRequest(
     headers.Authorization = `Bearer ${conn.accessToken}`;
   }
 
+  const httpProxy =
+    process.env.https_proxy ?? process.env.http_proxy ?? process.env.HTTPS_PROXY ?? process.env.HTTP_PROXY;
+
   const response = await fetch(normalizedUrl, {
     method: 'GET',
     headers,
+    dispatcher: httpProxy ? new ProxyAgent(httpProxy) : undefined,
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## Summary
- `bulkRequest()` in `bulkUtils.ts` bypasses jsforce to stream results without buffering, but the original implementation didn't carry over jsforce's proxy handling
- Job creation/polling goes through jsforce's transport which reads `HTTP_PROXY`/`https_proxy` env vars and creates a `ProxyAgent` dispatcher — but the results download called bare `undici` `fetch` with no dispatcher
- This caused "Fetch Failed (10)" errors in proxy-restricted environments, since proxy env vars were completely ignored during the results retrieval phase
- Fix: read proxy env vars and pass a `ProxyAgent` dispatcher to undici's fetch, matching the pattern in jsforce's `request.ts`

@W-23893215@
@W-23816212@
https://github.com/forcedotcom/cli/issues/3620

## Test plan
- [ ] Verify build passes (`npm run build`)
- [ ] Verify existing unit tests pass (`npm test`)
- [ ] Manual verification in a proxy-restricted environment: run `sf data export bulk` with `--wait` and confirm results are retrieved without needing `NODE_USE_ENV_PROXY=1`